### PR TITLE
feat: ability to provide flags to regex

### DIFF
--- a/lib/models/core/predicate.ts
+++ b/lib/models/core/predicate.ts
@@ -158,7 +158,10 @@ export class SNPredicate {
       return this.resolveIncludesPredicate(valueAtKeyPath, targetValue);
     }
     else if (predicate.operator === 'matches') {
-      const regex = new RegExp(targetValue as string);
+      const regexParams = targetValue as any[];
+      const pattern = typeof (regexParams) === 'object' ? regexParams[0] : regexParams;
+      const flags = typeof (regexParams) === 'object' ? regexParams[1] : 'gm';
+      const regex = new RegExp(pattern, flags);
       return regex.test(valueAtKeyPath);
     }
     return false;

--- a/test/predicate.test.js
+++ b/test/predicate.test.js
@@ -410,4 +410,28 @@ describe('predicates', async function () {
     );
     expect(itemManager.itemsMatchingPredicate(predicate).length).to.equal(1);
   });
+
+  it('regex with flags', async function () {
+    const itemManager = this.itemManager;
+    await itemManager.createItem(
+      ContentType.Note,
+      {
+        title: 'FOO',
+        text: 'BAR'
+      }
+    );
+    await itemManager.createItem(
+      ContentType.Note,
+      {
+        title: 'Foo',
+        text: 'Bar'
+      }
+    );
+
+    const predicateWithoutFlags = new SNPredicate('content.title', 'matches', '^foo');
+    expect(itemManager.itemsMatchingPredicate(predicateWithoutFlags).length).to.equal(0);
+
+    const predicateWithFlags = new SNPredicate('content.title', 'matches', ['^foo', 'gmi']);
+    expect(itemManager.itemsMatchingPredicate(predicateWithFlags).length).to.equal(2);
+  });
 });


### PR DESCRIPTION
Specially useful to create SmartTags with case insensitive match.

Example syntax:

```
!["Daylog entries", "title", "matches", ["^daylog", "gi"]]
```