### PR TITLE
fix: SNProtocolService: return computed server password when changing password

### DIFF
--- a/lib/application.ts
+++ b/lib/application.ts
@@ -1086,7 +1086,7 @@ export class SNApplication {
     if (error) return { error };
 
     const {
-      previousRootKey,
+      currentServerPassword,
       newRootKey,
       newKeyParams,
       rollback: rollbackPasswordChange
@@ -1105,7 +1105,7 @@ export class SNApplication {
 
     /** Now, change the password on the server. Roll back on failure */
     const response = await this.sessionManager!.changePassword(
-      previousRootKey.serverPassword,
+      currentServerPassword,
       newRootKey.serverPassword,
       newKeyParams
     );

--- a/lib/services/protocol_service.ts
+++ b/lib/services/protocol_service.ts
@@ -1336,7 +1336,7 @@ export class SNProtocolService extends PureService implements EncryptionDelegate
     newPassword: string,
     wrappingKey?: SNRootKey
   ): Promise<[Error | null, {
-    previousRootKey: SNRootKey,
+    currentServerPassword: string,
     newRootKey: SNRootKey,
     newKeyParams: SNRootKeyParams,
     rollback: () => Promise<void>
@@ -1367,7 +1367,7 @@ export class SNProtocolService extends PureService implements EncryptionDelegate
     return [
       null,
       {
-        previousRootKey: currentRootKey,
+        currentServerPassword: computedRootKey.serverPassword,
         newRootKey,
         newKeyParams,
         rollback: async () => {


### PR DESCRIPTION
Tightening up the changePassword API from the protocol service by not returning the previous root key but only the current server password, which is the only thing that's actually needed by clients.
This password is now also derived from the identical but computed root key instead of the stored root key because the latter is not always guaranteed to have the serverPassword stored in the way that our current SNRootKey class expects. This would make launching the app from a pure 003 installation and performing a protocol upgrade fail.