### PR TITLE
fix: correct WebPrefKey for EditorMonospaceEnabled

### DIFF
--- a/lib/models/app/userPrefs.ts
+++ b/lib/models/app/userPrefs.ts
@@ -6,7 +6,7 @@ export enum WebPrefKey {
   NotesPanelWidth = 'notesPanelWidth',
   EditorWidth = 'editorWidth',
   EditorLeft = 'editorLeft',
-  EditorMonospaceEnabled = 'monospaceFont',
+  EditorMonospaceEnabled = 'monospaceEnabled',
   EditorSpellcheck = 'spellcheck',
   EditorResizersEnabled = 'marginResizersEnabled',
   SortNotesBy = 'sortBy',


### PR DESCRIPTION
The enum value for `EditorMonospaceEnabled` should be [monospaceEnabled](https://github.com/standardnotes/web/blob/4dbf879f873cfea56bb6e8f9599bcf6453a60961/app/assets/javascripts/controllers/editor.js#L806).