### PR TITLE
Fix: upgrade with no account and a passcode

### DIFF
--- a/lib/application.ts
+++ b/lib/application.ts
@@ -1187,7 +1187,7 @@ export class SNApplication {
   }
 
 
-  public async generateUuid() {
+  public generateUuid() {
     return Uuid.GenerateUuid();
   }
 

--- a/lib/application.ts
+++ b/lib/application.ts
@@ -717,9 +717,9 @@ export class SNApplication {
       if (changeResponse?.error) {
         return [changeResponse!.error];
       }
-      if (passcode) {
-        await this.changePasscode(passcode);
-      }
+    }
+    if (passcode) {
+      await this.changePasscode(passcode);
     }
   }
 

--- a/lib/services/storage_service.ts
+++ b/lib/services/storage_service.ts
@@ -178,7 +178,7 @@ export class SNStorageService extends PureService {
     const wrappedValue = this.values[ValueModesKeys.Wrapped];
     const decryptedPayload = await this.decryptWrappedValue(wrappedValue);
     if (decryptedPayload.errorDecrypting) {
-      throw 'Unable to decrypt storage.';
+      throw Error('Unable to decrypt storage.');
     }
     this.values[ValueModesKeys.Unwrapped] = Copy(decryptedPayload.contentObject);
     delete this.values[ValueModesKeys.Wrapped];
@@ -231,7 +231,7 @@ export class SNStorageService extends PureService {
 
   public async setValue(key: string, value: any, mode = StorageValueModes.Default) {
     if (!this.values) {
-      throw `Attempting to set storage key ${key} before loading local storage.`;
+      throw Error(`Attempting to set storage key ${key} before loading local storage.`);
     }
     this.values[this.domainKeyForMode(mode)]![key] = value;
     return this.repersistToDisk();
@@ -239,17 +239,17 @@ export class SNStorageService extends PureService {
 
   public async getValue(key: string, mode = StorageValueModes.Default) {
     if (!this.values) {
-      throw `Attempting to get storage key ${key} before loading local storage.`;
+      throw Error(`Attempting to get storage key ${key} before loading local storage.`);
     }
     if (!this.values[this.domainKeyForMode(mode)]) {
-      throw `Storage domain mode not available ${mode} for key ${key}`;
+      throw Error(`Storage domain mode not available ${mode} for key ${key}`);
     }
     return this.values[this.domainKeyForMode(mode)]![key];
   }
 
   public async removeValue(key: string, mode = StorageValueModes.Default) {
     if (!this.values) {
-      throw `Attempting to remove storage key ${key} before loading local storage.`;
+      throw Error(`Attempting to remove storage key ${key} before loading local storage.`);
     }
     delete this.values[this.domainKeyForMode(mode)]![key];
     return this.repersistToDisk();
@@ -292,7 +292,7 @@ export class SNStorageService extends PureService {
     } else if (mode === StorageValueModes.Nonwrapped) {
       return ValueModesKeys.Nonwrapped;
     } else {
-      throw 'Invalid mode';
+      throw Error('Invalid mode');
     }
   }
 

--- a/lib/services/storage_service.ts
+++ b/lib/services/storage_service.ts
@@ -50,7 +50,7 @@ type PayloadEncryptionFunction = (payload: PurePayload, intent: EncryptionIntent
  * The storage service is responsible for persistence of both simple key-values, and payload
  * storage. It does so by relying on deviceInterface to save and retrieve raw values and payloads.
  * For simple key/values, items are grouped together in an in-memory hash, and persisted to disk
- * as a single object (encrypted, when possible). It handles persisting payloads in the local 
+ * as a single object (encrypted, when possible). It handles persisting payloads in the local
  * database by encrypting the payloads when possible.
  * The storage service also exposes methods that allow the application to initially
  * decrypt the persisted key/values, and also a method to determine whether a particular

--- a/lib/services/storage_service.ts
+++ b/lib/services/storage_service.ts
@@ -108,14 +108,11 @@ export class SNStorageService extends PureService {
   }
 
   public async initializeFromDisk() {
-    this.setInitialValues(await this.getValuesFromStorage());
-  }
-
-  private async getValuesFromStorage(): Promise<StorageValuesObject | undefined> {
     const value = await this.deviceInterface!.getRawStorageValue(
       this.getPersistenceKey()
     );
-    return value ? JSON.parse(value) : undefined;
+    const values = value ? JSON.parse(value) : undefined;
+    this.setInitialValues(values);
   }
 
   /**
@@ -138,11 +135,7 @@ export class SNStorageService extends PureService {
   }
 
   public async canDecryptWithKey(key: SNRootKey) {
-    let wrappedValue = this.values[ValueModesKeys.Wrapped];
-    if (!wrappedValue) {
-      const values = await this.getValuesFromStorage();
-      wrappedValue = values![ValueModesKeys.Wrapped];
-    }
+    const wrappedValue = this.values[ValueModesKeys.Wrapped];
     const decryptedPayload = await this.decryptWrappedValue(
       wrappedValue,
       key,
@@ -181,7 +174,6 @@ export class SNStorageService extends PureService {
       throw Error('Unable to decrypt storage.');
     }
     this.values[ValueModesKeys.Unwrapped] = Copy(decryptedPayload.contentObject);
-    delete this.values[ValueModesKeys.Wrapped];
   }
 
   /**


### PR DESCRIPTION
I investigated doing this during the storage upgrade but it would have involved much more work, so instead it works like account-based upgrades.