### PR TITLE
Better protocol upgrade api + blocking dialog

### DIFF
--- a/dist/@types/application.d.ts
+++ b/dist/@types/application.d.ts
@@ -223,10 +223,11 @@ export declare class SNApplication {
      * Returns true if there is an encryption source available
      */
     isEncryptionAvailable(): Promise<boolean>;
-    /**
-     * @returns An array of errors, if any.
-     */
-    upgradeProtocolVersion(): Promise<Error[] | undefined>;
+    upgradeProtocolVersion(): Promise<{
+        success?: true;
+        canceled?: true;
+        error?: Error;
+    }>;
     noAccount(): boolean;
     hasAccount(): boolean;
     /**

--- a/dist/@types/application.d.ts
+++ b/dist/@types/application.d.ts
@@ -77,7 +77,7 @@ export declare class SNApplication {
      * and 'with'  is the custom subclass to use.
      * @param skipClasses An array of classes to skip making services for.
      */
-    constructor(environment: Environment, platform: Platform, deviceInterface: DeviceInterface, crypto: SNPureCrypto, namespace?: string, swapClasses?: any[], skipClasses?: any[]);
+    constructor(environment: Environment, platform: Platform, deviceInterface: DeviceInterface, crypto: SNPureCrypto, alertService: SNAlertService, namespace?: string, swapClasses?: any[], skipClasses?: any[]);
     /**
      * The first thing consumers should call when starting their app.
      * This function will load all services in their correct order.
@@ -342,7 +342,6 @@ export declare class SNApplication {
     private constructServices;
     private clearServices;
     private createMigrationService;
-    private createAlertManager;
     private createApiService;
     private createItemManager;
     private createComponentManager;

--- a/dist/@types/index.d.ts
+++ b/dist/@types/index.d.ts
@@ -26,7 +26,8 @@ export { SNSyncService, SyncSources, SyncModes, SyncQueueStrategy, } from './ser
 export { SortPayloadsByRecentAndContentPriority } from './services/sync/utils';
 export { SNSessionManager } from './services/api/session_manager';
 export { SNMigrationService } from './services/migration_service';
-export { SNAlertService } from './services/alert_service';
+export { ButtonType } from './services/alert_service';
+export type { DismissBlockingDialog, SNAlertService } from './services/alert_service';
 export { SNHistoryManager } from './services/history/history_manager';
 export { SNPrivilegesService } from './services/privileges_service';
 export { SNSingletonManager } from './services/singleton_manager';

--- a/dist/@types/services/alert_service.d.ts
+++ b/dist/@types/services/alert_service.d.ts
@@ -1,12 +1,10 @@
-import { PureService } from './pure_service';
-import { DeviceInterface } from '../device_interface';
-/**
- * Can be subclassed to provide custom alert/confirm implementation.
- * Defaults to using browser alert() and confirm().
- */
-export declare class SNAlertService extends PureService {
-    constructor(deviceInterface: DeviceInterface);
-    deinit(): void;
-    alert(text?: string, title?: string, closeButtonText?: string, onClose?: () => void): Promise<unknown>;
-    confirm(text?: string, title?: string, confirmButtonText?: string, cancelButtonText?: string, onConfirm?: () => void, onCancel?: () => void, destructive?: boolean): Promise<unknown>;
+export declare enum ButtonType {
+    Info = 0,
+    Danger = 1
 }
+export declare type DismissBlockingDialog = () => void;
+export declare type SNAlertService = {
+    confirm(text: string, title?: string, confirmButtonText?: string, confirmButtonType?: ButtonType, cancelButtonText?: string): Promise<boolean>;
+    alert(text: string, title?: string, closeButtonText?: string): Promise<void>;
+    blockingDialog(text: string): DismissBlockingDialog;
+};

--- a/dist/@types/services/index.d.ts
+++ b/dist/@types/services/index.d.ts
@@ -1,4 +1,5 @@
-export { SNAlertService } from './alert_service';
+export { ButtonType } from './alert_service';
+export type { DismissBlockingDialog, SNAlertService } from './alert_service';
 export { SNSessionManager } from './api/session_manager';
 export { SNApiService } from './api/api_service';
 export { SNComponentManager } from './component_manager';

--- a/lib/application.ts
+++ b/lib/application.ts
@@ -135,27 +135,32 @@ export class SNApplication {
     platform: Platform,
     deviceInterface: DeviceInterface,
     crypto: SNPureCrypto,
+    alertService: SNAlertService,
     namespace?: string,
     swapClasses?: any[],
     skipClasses?: any[],
   ) {
     if (!deviceInterface) {
-      throw 'Device Interface must be supplied.';
+      throw Error('Device Interface must be supplied.');
     }
     if (!environment) {
-      throw 'Environment must be supplied when creating an application.';
+      throw Error('Environment must be supplied when creating an application.');
     }
     if (!platform) {
-      throw 'Platform must be supplied when creating an application.';
+      throw Error('Platform must be supplied when creating an application.');
     }
     if (!crypto) {
-      throw 'Crypto has to be supplied when creating an application.';
+      throw Error('Crypto has to be supplied when creating an application.');
+    }
+    if (!alertService) {
+      throw Error('AlertService must be supplied when creating an application.');
     }
     this.environment = environment;
     this.platform = platform;
     this.namespace = namespace || '';
     this.deviceInterface = deviceInterface;
     this.crypto = crypto;
+    this.alertService = alertService;
     this.swapClasses = swapClasses;
     this.skipClasses = skipClasses;
     this.constructServices();
@@ -1243,7 +1248,6 @@ export class SNApplication {
 
     this.createChallengeService();
     this.createMigrationService();
-    this.createAlertManager();
     this.createHttpManager();
     this.createApiService();
     this.createSessionManager();
@@ -1289,16 +1293,6 @@ export class SNApplication {
       }
     );
     this.services.push(this.migrationService!);
-  }
-
-  private createAlertManager() {
-    if (this.shouldSkipClass(SNAlertService)) {
-      return;
-    }
-    this.alertService = new (this.getClass(SNAlertService))(
-      this.deviceInterface
-    );
-    this.services.push(this.alertService!);
   }
 
   private createApiService() {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -63,7 +63,8 @@ export {
 export { SortPayloadsByRecentAndContentPriority } from './services/sync/utils';
 export { SNSessionManager } from './services/api/session_manager';
 export { SNMigrationService } from './services/migration_service';
-export { SNAlertService } from './services/alert_service';
+export { ButtonType } from './services/alert_service';
+export type { DismissBlockingDialog, SNAlertService } from './services/alert_service';
 export { SNHistoryManager } from './services/history/history_manager';
 export { SNPrivilegesService } from './services/privileges_service';
 export { SNSingletonManager } from './services/singleton_manager';

--- a/lib/services/actions_service.ts
+++ b/lib/services/actions_service.ts
@@ -164,27 +164,18 @@ export class SNActionsService extends PureService {
     action: Action,
     passwordRequestHandler: PasswordRequestHandler
   ): Promise<ActionResponse> {
-    return new Promise((resolve) => {
-      this.alertService!.confirm(
-        "Are you sure you want to replace the current note contents with this action's results?",
-        undefined,
-        undefined,
-        undefined,
-        () => {
-          this.runConfirmedGetAction(action, passwordRequestHandler)
-            .then((response) => {
-              resolve(response);
-            });
-        },
-        () => {
-          resolve({
-            error: {
-              message: 'Action canceled by user.' 
-            }
-          });
+    const confirmed = await this.alertService!.confirm(
+      "Are you sure you want to replace the current note contents with this action's results?"
+    )
+    if (confirmed) {
+      return this.runConfirmedGetAction(action, passwordRequestHandler);
+    } else {
+      return {
+        error: {
+          message: 'Action canceled by user.'
         }
-      );
-    });
+      }
+    }
   }
 
   private async runConfirmedGetAction(

--- a/lib/services/actions_service.ts
+++ b/lib/services/actions_service.ts
@@ -26,7 +26,7 @@ export type ActionResponse = {
 
 /**
  * The Actions Service allows clients to interact with action-based extensions.
- * Action-based extensions are mostly RESTful actions that can push a local value or 
+ * Action-based extensions are mostly RESTful actions that can push a local value or
  * retrieve a remote value and act on it accordingly.
  * There are 4 action types:
  * `get`: performs a GET request on an endpoint to retrieve an item value, and merges the
@@ -94,9 +94,9 @@ export class SNActionsService extends PureService {
   }
 
   /**
-   * Loads an extension in the context of a certain item. 
+   * Loads an extension in the context of a certain item.
    * The server then has the chance to respond with actions that are
-   * relevant just to this item. The response extension is not saved, 
+   * relevant just to this item. The response extension is not saved,
    * just displayed as a one-time thing.
   */
   public async loadExtensionInContextOfItem(extension: SNActionsExtension, item: SNItem) {
@@ -254,8 +254,8 @@ export class SNActionsService extends PureService {
     }
     if (!response.auth_params) {
       /**
-       * In some cases revisions were missing auth params. 
-       * Instruct the user to email us to get this remedied. 
+       * In some cases revisions were missing auth params.
+       * Instruct the user to email us to get this remedied.
        */
       this.alertService!.alert(
         'We were unable to decrypt this revision using your current keys, ' +

--- a/lib/services/alert_service.ts
+++ b/lib/services/alert_service.ts
@@ -1,52 +1,18 @@
-import { PureService } from '@Lib/services/pure_service';
-import { DeviceInterface } from '../device_interface';
+export enum ButtonType {
+  Info = 0,
+  Danger = 1,
+}
 
-/**
- * Can be subclassed to provide custom alert/confirm implementation.
- * Defaults to using browser alert() and confirm().
- */
-export class SNAlertService extends PureService {
+export type DismissBlockingDialog = () => void;
 
-  constructor(deviceInterface: DeviceInterface) {
-    super();
-    this.deviceInterface = deviceInterface;
-  }
-
-  deinit() {
-    this.deviceInterface = undefined;
-    super.deinit();
-  }
-
-  async alert(
-    text?: string,
+export type SNAlertService = {
+  confirm(
+    text: string,
     title?: string,
-    closeButtonText = 'OK',
-    onClose?: () => void
-  ) {
-    return new Promise((resolve, reject) => {
-      window.alert(text);
-      resolve();
-    });
-  }
-
-  async confirm(
-    text?: string,
-    title?: string,
-    confirmButtonText = 'Confirm',
-    cancelButtonText = 'Cancel',
-    onConfirm?: () => void,
-    onCancel?: () => void,
-    destructive = false
-  ) {
-    return new Promise((resolve, reject) => {
-      if (window.confirm(text)) {
-        onConfirm && onConfirm();
-        resolve();
-      } else {
-        // eslint-disable-next-line prefer-promise-reject-errors
-        onCancel && onCancel();
-        reject();
-      }
-    });
-  }
+    confirmButtonText?: string,
+    confirmButtonType?: ButtonType,
+    cancelButtonText?: string
+  ): Promise<boolean>;
+  alert(text: string, title?: string, closeButtonText?: string): Promise<void>;
+  blockingDialog(text: string): DismissBlockingDialog
 }

--- a/lib/services/api/messages.ts
+++ b/lib/services/api/messages.ts
@@ -45,7 +45,7 @@ export const INVALID_PASSWORD                      = `Invalid password.`;
 
 export const OUTDATED_PROTOCOL_ALERT_TITLE         = 'Update Recommended';
 export const OUTDATED_PROTOCOL_ALERT_IGNORE        = 'Sign In';
-export const UPGRADING_ENCRYPTION                  = 'Upgrading the account encryption. Do not close the application.';
+export const UPGRADING_ENCRYPTION                  = `Your account's encryption version is being upgraded. Do not close the application until this process completes.`;
 
 export function InsufficientPasswordMessage(minimum: number) {
   return `

--- a/lib/services/api/messages.ts
+++ b/lib/services/api/messages.ts
@@ -45,6 +45,7 @@ export const INVALID_PASSWORD                      = `Invalid password.`;
 
 export const OUTDATED_PROTOCOL_ALERT_TITLE         = 'Update Recommended';
 export const OUTDATED_PROTOCOL_ALERT_IGNORE        = 'Sign In';
+export const UPGRADING_ENCRYPTION                  = 'Upgrading the account encryption. Do not close the application.';
 
 export function InsufficientPasswordMessage(minimum: number) {
   return `

--- a/lib/services/api/session_manager.ts
+++ b/lib/services/api/session_manager.ts
@@ -185,9 +185,7 @@ export class SNSessionManager extends PureService {
         message,
         messages.OUTDATED_PROTOCOL_ALERT_TITLE,
         messages.OUTDATED_PROTOCOL_ALERT_IGNORE,
-      ).catch(() => {
-        /* No-op */
-      });
+      );
       if (!confirmed) {
         return {
           response: this.apiService!.createErrorResponse(messages.API_MESSAGE_FALLBACK_LOGIN_FAIL)

--- a/lib/services/api/session_manager.ts
+++ b/lib/services/api/session_manager.ts
@@ -252,7 +252,7 @@ export class SNSessionManager extends PureService {
     const user = response.user;
     this.user = user;
     await this.storageService!.setValue(StorageKey.User, user);
-    /* 
+    /*
       The token from response can be undefined if the user is using session tokens (protocol version >= 004).
       We should call setSession only if the session is updated with a new token.
     */

--- a/lib/services/component_manager.ts
+++ b/lib/services/component_manager.ts
@@ -952,12 +952,9 @@ export class SNComponentManager extends PureService {
       const itemsData = message.data.items;
       const noun = itemsData.length === 1 ? 'item' : 'items';
       let reply = null;
-      let didConfirm = true;
-      await this.alertService!.confirm(
+      const didConfirm = await this.alertService!.confirm(
         `Are you sure you want to delete ${itemsData.length} ${noun}?`
-      ).catch(() => {
-        didConfirm = false;
-      });
+      );
       if (didConfirm) {
         /* Filter for any components and deactivate before deleting */
         for (const itemData of itemsData) {

--- a/lib/services/index.ts
+++ b/lib/services/index.ts
@@ -1,4 +1,5 @@
-export { SNAlertService } from '@Services/alert_service';
+export { ButtonType } from '@Services/alert_service';
+export type { DismissBlockingDialog, SNAlertService } from '@Services/alert_service';
 export { SNSessionManager } from '@Services/api/session_manager';
 export { SNApiService } from '@Services/api/api_service';
 export { SNComponentManager } from '@Services/component_manager';

--- a/lib/services/model_manager.ts
+++ b/lib/services/model_manager.ts
@@ -154,7 +154,7 @@ export class PayloadManager extends PureService {
       }
       const masterPayload = this.collection.find(payload.uuid!);
       const newPayload = masterPayload ? PayloadByMerging(masterPayload, payload) : payload;
-      /** The item has been deleted and synced, 
+      /** The item has been deleted and synced,
        * and can thus be removed from our local record */
       if (newPayload.discardable) {
         this.collection.discard(newPayload);
@@ -171,10 +171,10 @@ export class PayloadManager extends PureService {
     return { changed, inserted, discarded };
   }
 
-  /** 
+  /**
    * Notifies observers when an item has been mapped.
    * @param types - An array of content types to listen for
-   * @param priority - The lower the priority, the earlier the function is called 
+   * @param priority - The lower the priority, the earlier the function is called
    *  wrt to other observers
    */
   public addObserver(
@@ -196,7 +196,7 @@ export class PayloadManager extends PureService {
     };
   }
 
-  /** 
+  /**
    * This function is mostly for internal use, but can be used externally by consumers who
    * explicitely understand what they are doing (want to propagate model state without mapping)
    */

--- a/lib/services/sync/sync_service.ts
+++ b/lib/services/sync/sync_service.ts
@@ -89,7 +89,7 @@ type SyncPromise = {
   options?: SyncOptions
 }
 
-/** 
+/**
  * The sync service orchestrates with the model manager, api service, and storage service
  * to ensure consistent state between the three. When a change is made to an item, consumers
  * call the sync service's sync function to first persist pending changes to local storage.
@@ -137,7 +137,7 @@ export class SNSyncService extends PureService {
   ];
   /**
    * Non-encrypted types are items whose values a server must be able to read.
-   * These include server extensions (such as a note history endpoint), and 
+   * These include server extensions (such as a note history endpoint), and
    * multi-factor authentication items, which include a secret value that the server
    * needs to be able to read in order to enforce.
    */
@@ -168,7 +168,7 @@ export class SNSyncService extends PureService {
     this.initializeState();
   }
 
-  /** 
+  /**
    * If the database has been newly created (because its new or was previously destroyed)
    * we want to reset any sync tokens we have.
    */
@@ -237,7 +237,7 @@ export class SNSyncService extends PureService {
     return this.opStatus;
   }
 
-  /** 
+  /**
    * Called by application when sign in or registration occurs.
    */
   public resetSyncState() {
@@ -248,7 +248,7 @@ export class SNSyncService extends PureService {
     return this.databaseLoaded;
   }
 
-  /** 
+  /**
    * Used in tandem with `loadDatabasePayloads`
    */
   public async getDatabasePayloads() {
@@ -258,7 +258,7 @@ export class SNSyncService extends PureService {
     });
   }
 
-  /** 
+  /**
    * @param rawPayloads - use `getDatabasePayloads` to get these payloads.
    * They are fed as a parameter so that callers don't have to await the loading, but can
    * await getting the raw payloads from storage
@@ -375,7 +375,7 @@ export class SNSyncService extends PureService {
 
   /**
    * Mark all items as dirty and needing sync, then persist to storage.
-   * @param alternateUuids  
+   * @param alternateUuids
    * In the case of signing in and merging local data, we alternate UUIDs
    * to avoid overwriting data a user may retrieve that has the same UUID.
    * Alternating here forces us to to create duplicates of the items instead.
@@ -460,9 +460,9 @@ export class SNSyncService extends PureService {
     });
   }
 
-  /** 
-   * Certain content types should not be encrypted when sending to server, 
-   * such as server extensions 
+  /**
+   * Certain content types should not be encrypted when sending to server,
+   * such as server extensions
    */
   private async payloadsByPreparingForServer(payloads: PurePayload[]) {
     return this.protocolService!.payloadsByEncryptingPayloads(
@@ -484,7 +484,7 @@ export class SNSyncService extends PureService {
       return;
     }
 
-    /** 
+    /**
      * Allows us to lock this function from triggering duplicate network requests.
      * There are two types of locking checks:
      * 1. syncLocked(): If a call to sync() call has begun preparing to be sent to the server.
@@ -563,11 +563,11 @@ export class SNSyncService extends PureService {
     /** Lock syncing immediately after checking in progress above */
     this.opStatus!.setDidBegin();
     this.notifyEvent(SyncEvent.SyncWillBegin);
-    /* Subtract from array as soon as we're sure they'll be called. 
+    /* Subtract from array as soon as we're sure they'll be called.
     resolves are triggered at the end of this function call */
     subtractFromArray(this.resolveQueue, inTimeResolveQueue);
 
-    /** lastSyncBegan must be set *after* any point we may have returned above. 
+    /** lastSyncBegan must be set *after* any point we may have returned above.
      * Setting this value means the item was 100% sent to the server. */
     const beginDate = new Date();
     if (items.length > 0) {
@@ -909,8 +909,8 @@ export class SNSyncService extends PureService {
     }
   }
 
-  /** 
-   * Downloads all items and maps to lcoal items to attempt resolve out-of-sync state 
+  /**
+   * Downloads all items and maps to lcoal items to attempt resolve out-of-sync state
    */
   public async resolveOutOfSync() {
     const downloader = new AccountDownloader(

--- a/test/application.test.js
+++ b/test/application.test.js
@@ -56,7 +56,7 @@ describe('application instances', () => {
     /** This test will always succeed but should be observed for console exceptions */
     const app = await Factory.createAndInitializeApplication('app');
     /** Don't await */
-    app.storageService.repersistToDisk();
+    app.storageService.persistValuesToDisk();
     await app.prepareForDeinit();
     app.deinit();
   });

--- a/test/lib/factory.js
+++ b/test/lib/factory.js
@@ -20,6 +20,11 @@ export function createApplication(namespace, environment, platform) {
     platform || Platform.MacWeb,
     deviceInterface,
     new SNWebCrypto(),
+    {
+      confirm: async () => true,
+      alert: async () => {},
+      blockingDialog: () => () => {},
+    },
     namespace,
     undefined,
     undefined

--- a/test/upgrading.test.js
+++ b/test/upgrading.test.js
@@ -105,8 +105,8 @@ describe('upgrading', () => {
     this.application.setLaunchCallback({
       receiveChallenge: this.receiveChallenge
     });
-    const errors = await this.application.upgradeProtocolVersion();
-    expect(errors).to.not.exist;
+    const result = await this.application.upgradeProtocolVersion();
+    expect(result).to.deep.equal({ success: true });
 
     const wrappedRootKey = await this.application.protocolService.getWrappedRootKey();
     const payload = CreateMaxPayloadFromAnyObject(wrappedRootKey);


### PR DESCRIPTION
- Makes SNAlertService a type which clients have to pass an implementation of in the constructor
- Adds `blockingDialog` method to SNAlertService
- Lets clients clearly know if the protocol upgrade succeeded, failed, or canceled.
- Shows a blocking dialog during the encryption upgrade process (likely needs a better message)