### PR TITLE
fix: uninstall active extensions

### DIFF
--- a/lib/services/component_manager.ts
+++ b/lib/services/component_manager.ts
@@ -1306,7 +1306,6 @@ export class SNComponentManager extends PureService {
     }
     this.findOrCreateDataForComponent(component).sessionKey = undefined;
     this.deregisterComponent(uuid);
-    this.syncService!.sync();
   }
 
   async reloadComponent(uuid: UuidString) {


### PR DESCRIPTION
The component manager's `deregisterComponent` method calls sync. Because sync is a very high-level operation with a lot of side-effects it can conflict when we're trying to do something after calling deregisterComponent. In this case, uninstalling it, which will be invalidated by the syncing request completing and determining that the just-disabled component should be kept.
I also think that in general calling sync inside a method named like this is surprising behavior. At least I expected it to do much less work when looking at it.