### PR TITLE
fix: extract sync out of activateComponent

### DIFF
--- a/lib/services/component_manager.ts
+++ b/lib/services/component_manager.ts
@@ -994,8 +994,9 @@ export class SNComponentManager extends PureService {
     });
   }
 
-  handleToggleComponentMessage(targetComponent: SNComponent, message: ComponentMessage) {
-    this.toggleComponent(targetComponent);
+  async handleToggleComponentMessage(targetComponent: SNComponent, message: ComponentMessage) {
+    await this.toggleComponent(targetComponent);
+    this.syncService.sync();
   }
 
   async toggleComponent(component: SNComponent) {
@@ -1268,7 +1269,6 @@ export class SNComponentManager extends PureService {
       });
     }
     this.registerComponent(uuid);
-    this.syncService!.sync();
   }
 
   deregisterComponent(uuid: UuidString) {


### PR DESCRIPTION
Aligns `activateComponent`'s behavior with `deactivateComponent`'s and calls sync at a higher level (as it turns out, most of the callers of this method ended up triggering a sync soon after)