### PR TITLE
Feature/conflict resolution while editing

### DIFF
--- a/dist/@types/models/app/component.d.ts
+++ b/dist/@types/models/app/component.d.ts
@@ -85,7 +85,7 @@ export declare class SNComponent extends SNItem implements ComponentContent {
     readonly isMobileDefault: boolean;
     constructor(payload: PurePayload);
     /** Do not duplicate components under most circumstances. Always keep original */
-    strategyWhenConflictingWithItem(item: SNItem): ConflictStrategy.KeepLeft | ConflictStrategy.KeepRight | ConflictStrategy.KeepLeftDuplicateRight | ConflictStrategy.KeepLeftMergeRefs;
+    strategyWhenConflictingWithItem(item: SNItem): ConflictStrategy;
     isEditor(): boolean;
     isTheme(): boolean;
     isDefaultEditor(): boolean;

--- a/dist/@types/models/app/items_key.d.ts
+++ b/dist/@types/models/app/items_key.d.ts
@@ -5,7 +5,7 @@ import { SNItem, ItemMutator } from '../core/item';
  */
 export declare class SNItemsKey extends SNItem {
     /** Do not duplicate items keys. Always keep original */
-    strategyWhenConflictingWithItem(item: SNItem): ConflictStrategy.KeepLeft | ConflictStrategy.KeepRight | ConflictStrategy.KeepLeftDuplicateRight | ConflictStrategy.KeepLeftMergeRefs;
+    strategyWhenConflictingWithItem(item: SNItem): ConflictStrategy;
     get version(): any;
     get isItemsKey(): boolean;
     get isDefault(): any;

--- a/dist/@types/models/app/theme.d.ts
+++ b/dist/@types/models/app/theme.d.ts
@@ -5,7 +5,7 @@ export declare class SNTheme extends SNComponent {
     area: ComponentArea;
     isLayerable(): any;
     /** Do not duplicate under most circumstances. Always keep original */
-    strategyWhenConflictingWithItem(item: SNItem): ConflictStrategy.KeepLeft | ConflictStrategy.KeepRight | ConflictStrategy.KeepLeftDuplicateRight | ConflictStrategy.KeepLeftMergeRefs;
+    strategyWhenConflictingWithItem(item: SNItem): ConflictStrategy;
     getMobileRules(): any;
     /** Same as getMobileRules but without default value. */
     hasMobileRules(): any;

--- a/dist/@types/models/core/item.d.ts
+++ b/dist/@types/models/core/item.d.ts
@@ -122,7 +122,7 @@ export declare class SNItem {
      * In the default implementation, we create a duplicate if content differs.
      * However, if they only differ by references, we KEEP_LEFT_MERGE_REFS.
      */
-    strategyWhenConflictingWithItem(item: SNItem): ConflictStrategy.KeepLeft | ConflictStrategy.KeepRight | ConflictStrategy.KeepLeftDuplicateRight | ConflictStrategy.KeepLeftMergeRefs;
+    strategyWhenConflictingWithItem(item: SNItem): ConflictStrategy;
     isItemContentEqualWith(otherItem: SNItem): boolean;
     satisfiesPredicate(predicate: SNPredicate): any;
     updatedAtTimestamp(): number;

--- a/dist/@types/services/component_manager.d.ts
+++ b/dist/@types/services/component_manager.d.ts
@@ -130,7 +130,7 @@ export declare class SNComponentManager extends PureService {
     handleDeleteItemsMessage(component: SNComponent, message: ComponentMessage): void;
     handleRequestPermissionsMessage(component: SNComponent, message: ComponentMessage): void;
     handleSetComponentDataMessage(component: SNComponent, message: ComponentMessage): void;
-    handleToggleComponentMessage(targetComponent: SNComponent, message: ComponentMessage): void;
+    handleToggleComponentMessage(targetComponent: SNComponent, message: ComponentMessage): Promise<void>;
     toggleComponent(component: SNComponent): Promise<void>;
     handleInstallLocalComponentMessage(sourceComponent: SNComponent, message: ComponentMessage): void;
     runWithPermissions(componentUuid: UuidString, requiredPermissions: ComponentPermission[], runFunction: () => void): void;

--- a/lib/models/core/item.ts
+++ b/lib/models/core/item.ts
@@ -284,15 +284,23 @@ export class SNItem {
     if (!contentDiffers) {
       return ConflictStrategy.KeepRight;
     }
-    const differsExclRefs = ItemContentsDiffer(
+    const itemsAreDifferentExcludingRefs = ItemContentsDiffer(
       this,
       item,
       ['references']
     );
-    if (differsExclRefs) {
-      return ConflictStrategy.KeepLeftDuplicateRight;
+    if (itemsAreDifferentExcludingRefs) {
+      const twentySeconds = 20_000;
+      if (Date.now() - this.userModifiedDate.getTime() < twentySeconds ) {
+        /**
+         * The user may be editing our item at this time, so duplicate the incoming
+         * item to avoid creating surprises in the client's UI.
+         */
+        return ConflictStrategy.KeepLeftDuplicateRight;
+      }
+      return ConflictStrategy.DuplicateLeftKeepRight;
     } else {
-      /** Is only references change */
+      /** Only the references have changed; merge them. */
       return ConflictStrategy.KeepLeftMergeRefs;
     }
   }

--- a/lib/models/core/item.ts
+++ b/lib/models/core/item.ts
@@ -297,8 +297,9 @@ export class SNItem {
          * item to avoid creating surprises in the client's UI.
          */
         return ConflictStrategy.KeepLeftDuplicateRight;
+      } else {
+        return ConflictStrategy.DuplicateLeftKeepRight;
       }
-      return ConflictStrategy.DuplicateLeftKeepRight;
     } else {
       /** Only the references have changed; merge them. */
       return ConflictStrategy.KeepLeftMergeRefs;


### PR DESCRIPTION
When two items have different contents:

- If the item was edited in the last 20 seconds, keep it, and duplicate the incoming item
- If the item was edited more than 20 seconds ago, duplicate it and keep the incoming item

Should we do this when an incoming item has been deleted as well?