### PR TITLE
try more than once when running downloadFirstSync

### DIFF
--- a/lib/application.ts
+++ b/lib/application.ts
@@ -1002,10 +1002,7 @@ export class SNApplication {
       }
       await this.notifyEvent(ApplicationEvent.SignedIn);
       this.unlockSyncing();
-      await this.syncService!.sync({
-        mode: SyncModes.DownloadFirst,
-        queueStrategy: SyncQueueStrategy.ForceSpawnNew
-      });
+      await this.syncService!.downloadFirstSync(300);
       this.protocolService!.decryptErroredItems();
     } else {
       this.unlockSyncing();
@@ -1056,10 +1053,8 @@ export class SNApplication {
       }
       await this.notifyEvent(ApplicationEvent.SignedIn);
       this.unlockSyncing();
-      const syncPromise = this.syncService!.sync({
-        mode: SyncModes.DownloadFirst,
+      const syncPromise = this.syncService!.downloadFirstSync(1_000, {
         checkIntegrity: true,
-        queueStrategy: SyncQueueStrategy.ForceSpawnNew,
         awaitAll: awaitSync,
       });
       if (awaitSync) {

--- a/lib/services/sync/sync_service.ts
+++ b/lib/services/sync/sync_service.ts
@@ -477,6 +477,23 @@ export class SNSyncService extends PureService {
     );
   }
 
+  public async downloadFirstSync(waitTimeOnFailureMs: number, otherSyncOptions?: SyncOptions) {
+    const maxTries = 5;
+    for (let i = 0; i < maxTries; i++) {
+      await this.sync({
+        mode: SyncModes.DownloadFirst,
+        queueStrategy: SyncQueueStrategy.ForceSpawnNew,
+        ...otherSyncOptions
+      }).catch(console.error);
+      if (this.completedOnlineDownloadFirstSync) {
+        return;
+      } else {
+        await sleep(waitTimeOnFailureMs);
+      }
+    }
+    console.error(`Failed downloadFirstSync after ${maxTries} tries`);
+  }
+
   public async sync(options: SyncOptions = {}): Promise<any> {
     /** Hard locking, does not apply to locking modes below */
     if (this.locked) {


### PR DESCRIPTION
The SyncService already makes sure that the first online sync is always a DownloadFirstSync. This means that even if this sync fails when we're signing in or registering things will get back in order once the next successful sync occurs.
This PR makes it so that if this initial sync request fails, we try again after a short delay, up to five times.