### PR TITLE
feature: add support for a "not" operator

### DIFF
--- a/lib/models/core/predicate.ts
+++ b/lib/models/core/predicate.ts
@@ -105,6 +105,11 @@ export class SNPredicate {
       targetValue = this.DateFromString(targetValue);
     }
 
+    /* Process not before handling the keypath, because not does not use it. */
+    if (predicate.operator === 'not') {
+      return !this.ObjectSatisfiesPredicate(object, targetValue);
+    }
+
     const valueAtKeyPath = predicate.keypath.split('.').reduce((previous, current) => {
       return previous && previous[current];
     }, object);

--- a/test/predicate.test.js
+++ b/test/predicate.test.js
@@ -120,6 +120,51 @@ describe('predicates', async function () {
     ]))).to.equal(false);
   });
 
+  it('test not operator', async function () {
+    const item = await this.createItem();
+    expect(item.satisfiesPredicate(new SNPredicate(
+      'this_field_ignored', 'not', ['content.title', '=', 'Not This Title']
+    ))).to.equal(true);
+    expect(item.satisfiesPredicate(new SNPredicate(
+      'this_field_ignored', 'not', ['content.title', '=', 'Hello']
+    ))).to.equal(false);
+
+    expect(item.satisfiesPredicate(new SNPredicate('', 'and', [
+      ['', 'not', ['content.tags', 'includes', ['title', '=', 'far']]],
+      ['content.tags', 'includes', ['title', '=', 'foo']],
+    ]))).to.equal(false);
+    expect(item.satisfiesPredicate(new SNPredicate('', 'and', [
+      ['', 'not', ['content.tags', 'includes', ['title', '=', 'boo']]],
+      ['content.tags', 'includes', ['title', '=', 'foo']],
+    ]))).to.equal(true);
+
+    expect(item.satisfiesPredicate(new SNPredicate('', 'not', [
+      '', 'and', [
+        ['content.title', 'startsWith', 'H'],
+        ['content.tags', 'includes', ['title', '=', 'falsify']]
+      ]
+    ]))).to.equal(true);
+    expect(item.satisfiesPredicate(new SNPredicate('', 'not', [
+      '', 'and', [
+        ['content.title', 'startsWith', 'H'],
+        ['content.tags', 'includes', ['title', '=', 'foo']]
+      ]
+    ]))).to.equal(false);
+
+    expect(item.satisfiesPredicate(new SNPredicate('', 'not', [
+      '', 'or', [
+        ['content.title', 'startsWith', 'H'],
+        ['content.tags', 'includes', ['title', '=', 'falsify']]
+      ]
+    ]))).to.equal(false);
+    expect(item.satisfiesPredicate(new SNPredicate('', 'not', [
+      '', 'or', [
+        ['content.title', 'startsWith', 'Z'],
+        ['content.tags', 'includes', ['title', '=', 'falsify']]
+      ]
+    ]))).to.equal(true);
+  });
+
   it('test deep nested recursive operator', async function () {
     const item = await this.createItem();
     expect(item.satisfiesPredicate(new SNPredicate('this_field_ignored', 'and', [


### PR DESCRIPTION
A not operator would allow you to build more powerful filters, which would be especially useful when dealing with an imported a tag hierarchy from another system that you're trying to clean up.

This was [discussed here](https://github.com/standardnotes/forum/issues/262#issuecomment-490623566). But rather than introducing a special syntax to parse, this just treats it as a top-level operator like and/or.

I couldn't find [the docs](https://standardnotes.org/help/42/how-do-i-view-a-list-of-untagged-notes-and-create-other-dynamic-filters) to update on Github. That should be done if this PR is accepted too.