### PR TITLE
feature: github action to check tsc on push

### DIFF
--- a/.github/workflows/tsc.yml
+++ b/.github/workflows/tsc.yml
@@ -1,0 +1,14 @@
+name: Typescript check
+
+on: [push]
+
+jobs:
+  tsc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: npm ci
+      - name: Compile Typescript
+        run: npm run tsc


### PR DESCRIPTION
Somehow running `npm run tsc` fails on the default branch. This motivated me to create a Github Action check so it's impossible to miss it next time when someone creates a PR. It runs `npm run tsc` on every push. 