### PR TITLE
Reland "feature: add support for a "not" operator" with the right types

### DIFF
--- a/dist/@types/models/core/item.d.ts
+++ b/dist/@types/models/core/item.d.ts
@@ -124,7 +124,7 @@ export declare class SNItem {
      */
     strategyWhenConflictingWithItem(item: SNItem): ConflictStrategy;
     isItemContentEqualWith(otherItem: SNItem): boolean;
-    satisfiesPredicate(predicate: SNPredicate): any;
+    satisfiesPredicate(predicate: SNPredicate): boolean;
     updatedAtTimestamp(): number;
     private dateToLocalizedString;
 }

--- a/dist/@types/models/core/predicate.d.ts
+++ b/dist/@types/models/core/predicate.d.ts
@@ -1,7 +1,7 @@
 import { SNItem } from './item';
 declare type PredicateType = string[] | SNPredicate;
 declare type PredicateArray = Array<string[]> | SNPredicate[];
-declare type PredicateValue = string | Date | boolean | PredicateArray;
+declare type PredicateValue = string | Date | boolean | PredicateType | PredicateArray;
 /**
  * A local-only construct that defines a built query that can be used to
  * dynamically search items.
@@ -17,14 +17,14 @@ export declare class SNPredicate {
     arrayRepresentation(): PredicateValue[];
     valueAsArray(): PredicateArray;
     static CompoundPredicate(predicates: PredicateArray): SNPredicate;
-    static ObjectSatisfiesPredicate(object: any, predicate: PredicateType): any;
+    static ObjectSatisfiesPredicate(object: any, predicate: PredicateType): boolean;
     /**
      * @param itemValueArray Because we are resolving the `includes` operator, the given
      * value should be an array.
      * @param containsValue  The value we are checking to see if exists in itemValueArray
      */
     static resolveIncludesPredicate(itemValueArray: Array<any>, containsValue: any): boolean;
-    static ItemSatisfiesPredicate(item: SNItem, predicate: SNPredicate): any;
+    static ItemSatisfiesPredicate(item: SNItem, predicate: SNPredicate): boolean;
     static ItemSatisfiesPredicates(item: SNItem, predicates: SNPredicate[]): boolean;
     /**
      * Predicate date strings are of form "x.days.ago" or "x.hours.ago"

--- a/dist/@types/services/sync/sync_service.d.ts
+++ b/dist/@types/services/sync/sync_service.d.ts
@@ -153,6 +153,7 @@ export declare class SNSyncService extends PureService {
      * such as server extensions
      */
     private payloadsByPreparingForServer;
+    downloadFirstSync(waitTimeOnFailureMs: number, otherSyncOptions?: SyncOptions): Promise<void>;
     sync(options?: SyncOptions): Promise<any>;
     private syncOnlineOperation;
     private syncOfflineOperation;

--- a/lib/models/core/predicate.ts
+++ b/lib/models/core/predicate.ts
@@ -2,7 +2,7 @@ import { SNItem } from '@Models/core/item';
 import { isString } from '@Lib/utils';
 type PredicateType = string[] | SNPredicate
 type PredicateArray = Array<string[]> | SNPredicate[]
-type PredicateValue = string | Date | boolean | PredicateArray;
+type PredicateValue = string | Date | boolean | PredicateType | PredicateArray;
 
 /**
  * A local-only construct that defines a built query that can be used to 
@@ -74,7 +74,7 @@ export class SNPredicate {
     );
   }
 
-  static ObjectSatisfiesPredicate(object: any, predicate: PredicateType) {
+  static ObjectSatisfiesPredicate(object: any, predicate: PredicateType): boolean {
     /* Predicates may not always be created using the official constructor
        so if it's still an array here, convert to object */
     if (Array.isArray(predicate)) {
@@ -103,6 +103,11 @@ export class SNPredicate {
     let targetValue = predicate.value;
     if (typeof (targetValue) === 'string' && targetValue.includes('.ago')) {
       targetValue = this.DateFromString(targetValue);
+    }
+
+    /* Process not before handling the keypath, because not does not use it. */
+    if (predicate.operator === 'not') {
+      return !this.ObjectSatisfiesPredicate(object, targetValue as PredicateType);
     }
 
     const valueAtKeyPath = predicate.keypath.split('.').reduce((previous, current) => {

--- a/test/predicate.test.js
+++ b/test/predicate.test.js
@@ -120,6 +120,51 @@ describe('predicates', async function () {
     ]))).to.equal(false);
   });
 
+  it('test not operator', async function () {
+    const item = await this.createItem();
+    expect(item.satisfiesPredicate(new SNPredicate(
+      'this_field_ignored', 'not', ['content.title', '=', 'Not This Title']
+    ))).to.equal(true);
+    expect(item.satisfiesPredicate(new SNPredicate(
+      'this_field_ignored', 'not', ['content.title', '=', 'Hello']
+    ))).to.equal(false);
+
+    expect(item.satisfiesPredicate(new SNPredicate('', 'and', [
+      ['', 'not', ['content.tags', 'includes', ['title', '=', 'far']]],
+      ['content.tags', 'includes', ['title', '=', 'foo']],
+    ]))).to.equal(false);
+    expect(item.satisfiesPredicate(new SNPredicate('', 'and', [
+      ['', 'not', ['content.tags', 'includes', ['title', '=', 'boo']]],
+      ['content.tags', 'includes', ['title', '=', 'foo']],
+    ]))).to.equal(true);
+
+    expect(item.satisfiesPredicate(new SNPredicate('', 'not', [
+      '', 'and', [
+        ['content.title', 'startsWith', 'H'],
+        ['content.tags', 'includes', ['title', '=', 'falsify']]
+      ]
+    ]))).to.equal(true);
+    expect(item.satisfiesPredicate(new SNPredicate('', 'not', [
+      '', 'and', [
+        ['content.title', 'startsWith', 'H'],
+        ['content.tags', 'includes', ['title', '=', 'foo']]
+      ]
+    ]))).to.equal(false);
+
+    expect(item.satisfiesPredicate(new SNPredicate('', 'not', [
+      '', 'or', [
+        ['content.title', 'startsWith', 'H'],
+        ['content.tags', 'includes', ['title', '=', 'falsify']]
+      ]
+    ]))).to.equal(false);
+    expect(item.satisfiesPredicate(new SNPredicate('', 'not', [
+      '', 'or', [
+        ['content.title', 'startsWith', 'Z'],
+        ['content.tags', 'includes', ['title', '=', 'falsify']]
+      ]
+    ]))).to.equal(true);
+  });
+
   it('test deep nested recursive operator', async function () {
     const item = await this.createItem();
     expect(item.satisfiesPredicate(new SNPredicate('this_field_ignored', 'and', [


### PR DESCRIPTION
This relands b21865baf6c54e46b67d1e80c6fef1bf2abb5385, which was
reverted by commit 316b1b0caa00bb2ad5dde07b3a473c1dba2a65c7.