### PR TITLE
Fix duplication strategy for imports

### DIFF
--- a/dist/@types/services/sync/sync_service.d.ts
+++ b/dist/@types/services/sync/sync_service.d.ts
@@ -153,6 +153,7 @@ export declare class SNSyncService extends PureService {
      * such as server extensions
      */
     private payloadsByPreparingForServer;
+    downloadFirstSync(waitTimeOnFailureMs: number, otherSyncOptions?: SyncOptions): Promise<void>;
     sync(options?: SyncOptions): Promise<any>;
     private syncOnlineOperation;
     private syncOfflineOperation;

--- a/lib/models/core/item.ts
+++ b/lib/models/core/item.ts
@@ -291,11 +291,18 @@ export class SNItem {
     );
     if (itemsAreDifferentExcludingRefs) {
       const twentySeconds = 20_000;
-      if (Date.now() - this.userModifiedDate.getTime() < twentySeconds ) {
+      if (
         /**
-         * The user may be editing our item at this time, so duplicate the incoming
-         * item to avoid creating surprises in the client's UI.
+         * If the incoming item comes from an import, treat it as
+         * less important than the existing one.
          */
+        item.payload.source === PayloadSource.FileImport ||
+        /**
+         * If the user is actively editing our item, duplicate the incoming item
+         * to avoid creating surprises in the client's UI.
+         */
+        Date.now() - this.userModifiedDate.getTime() < twentySeconds
+      ) {
         return ConflictStrategy.KeepLeftDuplicateRight;
       } else {
         return ConflictStrategy.DuplicateLeftKeepRight;


### PR DESCRIPTION
As reported by @johnny243 to me in private, two tests are currently failing because they expect imported data with identical UUIDs but differing contents to be duplicated. This PR fixes that.