### PR TITLE
feature: make alertService protected in Component Manager

### DIFF
--- a/dist/@types/services/component_manager.d.ts
+++ b/dist/@types/services/component_manager.d.ts
@@ -74,7 +74,7 @@ declare type ComponentState = {
 export declare class SNComponentManager extends PureService {
     private itemManager;
     private syncService;
-    private alertService;
+    protected alertService: SNAlertService;
     private environment;
     private platform;
     private timeout;

--- a/lib/services/component_manager.ts
+++ b/lib/services/component_manager.ts
@@ -121,7 +121,7 @@ export class SNComponentManager extends PureService {
 
   private itemManager!: ItemManager
   private syncService!: SNSyncService
-  private alertService!: SNAlertService
+  protected alertService!: SNAlertService
   private environment: Environment
   private platform: Platform
   private timeout: any


### PR DESCRIPTION
This enables classes that extend Component Manager to use alert service. Useful for `presentPermissionsDialog`.