### PR TITLE
Actually clear all data

### DIFF
--- a/dist/@types/services/storage_service.d.ts
+++ b/dist/@types/services/storage_service.d.ts
@@ -92,6 +92,6 @@ export declare class SNStorageService extends PureService {
     deletePayloads(payloads: PurePayload[]): Promise<void>;
     deletePayloadWithId(id: string): Promise<void>;
     clearAllPayloads(): Promise<void>;
-    clearAllData(): Promise<[void, void]>;
+    clearAllData(): Promise<void>;
 }
 export {};

--- a/dist/snjs.js
+++ b/dist/snjs.js
@@ -10548,8 +10548,12 @@ class storage_service_SNStorageService extends pure_service["a" /* PureService *
       throw Error("Attempting to remove storage key ".concat(key, " before loading local storage."));
     }
 
-    delete this.values[this.domainKeyForMode(mode)][key];
-    return this.persistValuesToDisk();
+    const domain = this.values[this.domainKeyForMode(mode)];
+
+    if (domain === null || domain === void 0 ? void 0 : domain[key]) {
+      delete domain[key];
+      return this.persistValuesToDisk();
+    }
   }
 
   getStorageEncryptionPolicy() {
@@ -10650,8 +10654,12 @@ class storage_service_SNStorageService extends pure_service["a" /* PureService *
     });
   }
 
-  async clearAllData() {
-    return Promise.all([this.clearValues(), this.clearAllPayloads()]);
+  clearAllData() {
+    return this.executeCriticalFunction(async () => {
+      await this.clearValues();
+      await this.clearAllPayloads();
+      await this.deviceInterface.removeRawStorageValue(this.getPersistenceKey());
+    });
   }
 
 }

--- a/lib/services/storage_service.ts
+++ b/lib/services/storage_service.ts
@@ -363,10 +363,11 @@ export class SNStorageService extends PureService {
     });
   }
 
-  public async clearAllData() {
-    return Promise.all([
-      this.clearValues(),
-      this.clearAllPayloads()
-    ]);
+  public clearAllData(): Promise<void> {
+    return this.executeCriticalFunction(async () => {
+      await this.clearValues();
+      await this.clearAllPayloads();
+      await this.deviceInterface!.removeRawStorageValue(this.getPersistenceKey());
+    });
   }
 }

--- a/lib/services/storage_service.ts
+++ b/lib/services/storage_service.ts
@@ -248,8 +248,11 @@ export class SNStorageService extends PureService {
     if (!this.values) {
       throw Error(`Attempting to remove storage key ${key} before loading local storage.`);
     }
-    delete this.values[this.domainKeyForMode(mode)]![key];
-    return this.persistValuesToDisk();
+    const domain = this.values[this.domainKeyForMode(mode)];
+    if (domain?.[key]) {
+      delete domain[key];
+      return this.persistValuesToDisk();
+    }
   }
 
   public getStorageEncryptionPolicy() {


### PR DESCRIPTION
Fixes: StorageService.clearAllData doesn't actually clear all data and can be invalidated by subsequent calls to removeValue.