### PR TITLE
fix: use mobile active themes in ComponentManager

### DIFF
--- a/dist/snjs.js
+++ b/dist/snjs.js
@@ -11758,6 +11758,12 @@ class component_manager_SNComponentManager extends pure_service["a" /* PureServi
   }
 
   getActiveThemes() {
+    if (this.environment === Environment.Mobile) {
+      return this.componentsForArea(ComponentArea.Themes).filter(theme => {
+        return theme.isMobileActive();
+      });
+    }
+
     return this.componentsForArea(ComponentArea.Themes).filter(theme => {
       return theme.active;
     });

--- a/lib/services/component_manager.ts
+++ b/lib/services/component_manager.ts
@@ -369,6 +369,11 @@ export class SNComponentManager extends PureService {
   }
 
   getActiveThemes() {
+    if (this.environment === Environment.Mobile) {
+      return this.componentsForArea(ComponentArea.Themes).filter((theme) => {
+        return (theme as SNTheme).isMobileActive();
+      }) as SNTheme[];
+    }
     return this.componentsForArea(ComponentArea.Themes).filter((theme) => {
       return theme.active;
     }) as SNTheme[];


### PR DESCRIPTION
Without this change, mobile-only active themes would not be passed to components. Is this enough?