### PR TITLE
feature: expose getAsboluteUrl from application

### DIFF
--- a/dist/@types/application.d.ts
+++ b/dist/@types/application.d.ts
@@ -347,6 +347,7 @@ export declare class SNApplication {
     getStorageEncryptionPolicy(): StorageEncryptionPolicies;
     setStorageEncryptionPolicy(encryptionPolicy: StorageEncryptionPolicies): Promise<void>;
     generateUuid(): Promise<string>;
+    getAbsoluteUrl(url: string): Promise<import("./services/api/http_service").HttpResponse> | undefined;
     /**
      * Dynamically change the device interface, i.e when Desktop wants to override
      * default web interface.

--- a/dist/snjs.js
+++ b/dist/snjs.js
@@ -22362,6 +22362,12 @@ class application_SNApplication {
   generateUuid() {
     return uuid_Uuid.GenerateUuid();
   }
+
+  getAbsoluteUrl(url) {
+    var _this$httpService;
+
+    return (_this$httpService = this.httpService) === null || _this$httpService === void 0 ? void 0 : _this$httpService.getAbsolute(url);
+  }
   /**
    * Dynamically change the device interface, i.e when Desktop wants to override
    * default web interface.

--- a/lib/application.ts
+++ b/lib/application.ts
@@ -1242,6 +1242,10 @@ export class SNApplication {
     return Uuid.GenerateUuid();
   }
 
+  public getAbsoluteUrl(url: string) {
+    return this.httpService?.getAbsolute(url);
+  }
+
   /**
    * Dynamically change the device interface, i.e when Desktop wants to override
    * default web interface.


### PR DESCRIPTION
This PR makes it possible to use http service by an application (to download themes on mobile). This could alternatively be in `MobileApplication`?