### PR TITLE
Remove storage leftovers after import

### DIFF
--- a/dist/@types/services/item_manager.d.ts
+++ b/dist/@types/services/item_manager.d.ts
@@ -110,10 +110,10 @@ export declare class ItemManager extends PureService {
      * @param mutate If not supplied, the intention would simply be to mark the item as dirty.
      */
     changeItems<M extends ItemMutator = ItemMutator>(uuids: UuidString[], mutate?: (mutator: M) => void, mutationType?: MutationType, payloadSource?: PayloadSource, payloadSourceKey?: string): Promise<(SNItem | undefined)[]>;
-    changeNote(uuid: UuidString, mutate: (mutator: NoteMutator) => void, mutationType?: MutationType, payloadSource?: PayloadSource, payloadSourceKey?: string): Promise<void>;
-    changeComponent(uuid: UuidString, mutate: (mutator: ComponentMutator) => void, mutationType?: MutationType, payloadSource?: PayloadSource, payloadSourceKey?: string): Promise<void>;
-    changeActionsExtension(uuid: UuidString, mutate: (mutator: ActionsExtensionMutator) => void, mutationType?: MutationType, payloadSource?: PayloadSource, payloadSourceKey?: string): Promise<void>;
-    changeItemsKey(uuid: UuidString, mutate: (mutator: ItemsKeyMutator) => void, mutationType?: MutationType, payloadSource?: PayloadSource, payloadSourceKey?: string): Promise<void>;
+    changeNote(uuid: UuidString, mutate: (mutator: NoteMutator) => void, mutationType?: MutationType, payloadSource?: PayloadSource, payloadSourceKey?: string): Promise<PurePayload[]>;
+    changeComponent(uuid: UuidString, mutate: (mutator: ComponentMutator) => void, mutationType?: MutationType, payloadSource?: PayloadSource, payloadSourceKey?: string): Promise<PurePayload[]>;
+    changeActionsExtension(uuid: UuidString, mutate: (mutator: ActionsExtensionMutator) => void, mutationType?: MutationType, payloadSource?: PayloadSource, payloadSourceKey?: string): Promise<PurePayload[]>;
+    changeItemsKey(uuid: UuidString, mutate: (mutator: ItemsKeyMutator) => void, mutationType?: MutationType, payloadSource?: PayloadSource, payloadSourceKey?: string): Promise<PurePayload[]>;
     private applyTransform;
     /**
       * Sets the item as needing sync. The item is then run through the mapping function,

--- a/dist/@types/services/model_manager.d.ts
+++ b/dist/@types/services/model_manager.d.ts
@@ -34,18 +34,21 @@ export declare class PayloadManager extends PureService {
      * One of many mapping helpers available.
      * This function maps a collection of payloads.
      */
-    emitCollection(collection: ImmutablePayloadCollection, sourceKey?: string): Promise<unknown>;
+    emitCollection(collection: ImmutablePayloadCollection, sourceKey?: string): Promise<PurePayload[]>;
     /**
      * One of many mapping helpers available.
      * This function maps a payload to an item
-     * @returns The mapped item
+     * @returns every paylod altered as a result of this operation, to be
+     * saved to storage by the caller
      */
-    emitPayload(payload: PurePayload, source: PayloadSource, sourceKey?: string): Promise<void>;
+    emitPayload(payload: PurePayload, source: PayloadSource, sourceKey?: string): Promise<PurePayload[]>;
     /**
      * This function maps multiple payloads to items, and is the authoratative mapping
      * function that all other mapping helpers rely on
+     * @returns every paylod altered as a result of this operation, to be
+     * saved to storage by the caller
      */
-    emitPayloads(payloads: PurePayload[], source: PayloadSource, sourceKey?: string): Promise<unknown>;
+    emitPayloads(payloads: PurePayload[], source: PayloadSource, sourceKey?: string): Promise<PurePayload[]>;
     private popQueue;
     private mergePayloadsOntoMaster;
     /**

--- a/dist/snjs.js
+++ b/dist/snjs.js
@@ -13716,16 +13716,19 @@ class model_manager_PayloadManager extends pure_service["a" /* PureService */] {
   /**
    * One of many mapping helpers available.
    * This function maps a payload to an item
-   * @returns The mapped item
+   * @returns every paylod altered as a result of this operation, to be
+   * saved to storage by the caller
    */
 
 
   async emitPayload(payload, source, sourceKey) {
-    await this.emitPayloads([payload], source, sourceKey);
+    return this.emitPayloads([payload], source, sourceKey);
   }
   /**
    * This function maps multiple payloads to items, and is the authoratative mapping
    * function that all other mapping helpers rely on
+   * @returns every paylod altered as a result of this operation, to be
+   * saved to storage by the caller
    */
 
 
@@ -13757,7 +13760,7 @@ class model_manager_PayloadManager extends pure_service["a" /* PureService */] {
     } = this.mergePayloadsOntoMaster(first.payloads);
     this.notifyChangeObservers(changed, inserted, discarded, first.source, first.sourceKey);
     Object(utils["B" /* removeFromArray */])(this.emitQueue, first);
-    first.resolve();
+    first.resolve(changed.concat(inserted, discarded));
 
     if (this.emitQueue.length > 0) {
       this.popQueue();
@@ -20825,8 +20828,7 @@ class sync_service_SNSyncService extends pure_service["a" /* PureService */] {
     const collections = await resolver.collectionsByProcessingResponse();
 
     for (const collection of collections) {
-      await this.modelManager.emitCollection(collection);
-      const payloadsToPersist = this.modelManager.find(collection.uuids());
+      const payloadsToPersist = await this.modelManager.emitCollection(collection);
       await this.persistPayloads(payloadsToPersist);
     }
 

--- a/lib/services/sync/sync_service.ts
+++ b/lib/services/sync/sync_service.ts
@@ -848,8 +848,7 @@ export class SNSyncService extends PureService {
 
     const collections = await resolver.collectionsByProcessingResponse();
     for (const collection of collections) {
-      await this.modelManager!.emitCollection(collection);
-      const payloadsToPersist = this.modelManager!.find(collection.uuids()) as PurePayload[];
+      const payloadsToPersist = await this.modelManager!.emitCollection(collection);
       await this.persistPayloads(payloadsToPersist);
     }
     const deletedPayloads = response.deletedPayloads;

--- a/test/model_tests/importing.test.js
+++ b/test/model_tests/importing.test.js
@@ -596,7 +596,7 @@ describe('importing', () => {
 
       await this.application.deinit();
       this.application = await Factory.createInitAppWithRandNamespace();
-      
+
       const result = await this.application.importData(
         JSON.parse(backupData),
         'not-the-correct-password-1234',

--- a/test/model_tests/importing.test.js
+++ b/test/model_tests/importing.test.js
@@ -271,6 +271,68 @@ describe('importing', () => {
       expect(this.application.findItem(note.uuid).deleted).to.be.false;
     });
 
+    it('should duplicate notes by alternating UUIDs when dealing with conflicts during importing', async function () {
+      await Factory.registerUserToApplication({
+        application: this.application,
+        email: this.email,
+        password: this.password,
+      });
+      const note = await Factory.createSyncedNote(this.application);
+
+      /** Sign into another account and import the same item. It should get a different UUID. */
+      this.application = await Factory.signOutApplicationAndReturnNew(this.application);
+      this.email = Uuid.GenerateUuidSynchronously();
+      await Factory.registerUserToApplication({
+        application: this.application,
+        email: this.email,
+        password: this.password,
+      });
+
+      await this.application.importData(
+        {
+          items: [note]
+        },
+        undefined,
+        true,
+      );
+
+      expect(this.application.itemManager.notes.length).to.equal(1);
+      expect(this.application.itemManager.notes[0].uuid).to.not.equal(note.uuid);
+    });
+
+    it('should maintain consistency between storage and PayloadManager after an import with conflicts', async function () {
+      await Factory.registerUserToApplication({
+        application: this.application,
+        email: this.email,
+        password: this.password,
+      });
+      const note = await Factory.createSyncedNote(this.application);
+
+      /** Sign into another account and import the same items. They should get a different UUID. */
+      this.application = await Factory.signOutApplicationAndReturnNew(this.application);
+      this.email = Uuid.GenerateUuidSynchronously();
+      await Factory.registerUserToApplication({
+        application: this.application,
+        email: this.email,
+        password: this.password,
+      });
+
+      await this.application.importData(
+        {
+          items: [note]
+        },
+        undefined,
+        true,
+      );
+
+      const storedPayloads = await this.application.storageService.getAllRawPayloads();
+      expect(this.application.itemManager.items.length).to.equal(storedPayloads.length);
+      const notes = storedPayloads.filter(p => p.content_type === ContentType.Note);
+      const itemsKeys = storedPayloads.filter(p => p.content_type === ContentType.ItemsKey);
+      expect(notes.length).to.equal(1);
+      expect(itemsKeys.length).to.equal(1);
+    });
+
     it('should import encrypted data and keep items that were previously deleted', async function () {
       await Factory.registerUserToApplication({
         application: this.application,


### PR DESCRIPTION
When importing items with UUIDs that conflict with the server, after alternating the UUID the original item was being discarded from PayloadManager but not from storage, causing the app to try to resync that item upon restarting.
With this change, PayloadManager.emitPayloads now returns all the items that it altered instead of letting the sync service query for them, leading to a more predictable and correct result.