### PR TITLE
refactor: simplify isEncryptionAvailable in application

### DIFF
--- a/dist/@types/application.d.ts
+++ b/dist/@types/application.d.ts
@@ -235,7 +235,7 @@ export declare class SNApplication {
     /**
      * Returns true if there is an encryption source available
      */
-    isEncryptionAvailable(): Promise<boolean>;
+    isEncryptionAvailable(): boolean;
     upgradeProtocolVersion(): Promise<{
         success?: true;
         canceled?: true;

--- a/dist/snjs.js
+++ b/dist/snjs.js
@@ -21848,13 +21848,13 @@ class application_SNApplication {
    */
 
 
-  async isEncryptionAvailable() {
-    return !Object(utils["p" /* isNullOrUndefined */])(this.getUser()) || this.hasPasscode();
+  isEncryptionAvailable() {
+    return this.hasAccount() || this.hasPasscode();
   }
 
   async upgradeProtocolVersion() {
     const hasPasscode = this.hasPasscode();
-    const hasAccount = !this.noAccount();
+    const hasAccount = this.hasAccount();
     const types = [];
 
     if (hasPasscode) {

--- a/lib/application.ts
+++ b/lib/application.ts
@@ -700,8 +700,8 @@ export class SNApplication {
   /**
    * Returns true if there is an encryption source available
    */
-  public async isEncryptionAvailable() {
-    return !isNullOrUndefined(this.getUser()) || this.hasPasscode();
+  public isEncryptionAvailable() {
+    return this.hasAccount() || this.hasPasscode();
   }
 
   public async upgradeProtocolVersion(): Promise<{
@@ -710,7 +710,7 @@ export class SNApplication {
     error?: Error,
   }> {
     const hasPasscode = this.hasPasscode();
-    const hasAccount = !this.noAccount();
+    const hasAccount = this.hasAccount();
     const types = [];
     if (hasPasscode) {
       types.push(ChallengeType.LocalPasscode);


### PR DESCRIPTION
We can avoid reading user for safety reasons and this method becomes synchronous as well.