### PR TITLE
display blocking dialog during passcode operations

### DIFF
--- a/lib/application.ts
+++ b/lib/application.ts
@@ -726,7 +726,7 @@ export class SNApplication {
     if (!response) {
       return { canceled: true };
     }
-    const dismissBlockingDialog = this.alertService!.blockingDialog(UPGRADING_ENCRYPTION);
+    const dismissBlockingDialog = await this.alertService!.blockingDialog(UPGRADING_ENCRYPTION);
     try {
       let passcode: string | undefined;
       if (hasPasscode) {

--- a/lib/services/alert_service.ts
+++ b/lib/services/alert_service.ts
@@ -14,5 +14,5 @@ export type SNAlertService = {
     cancelButtonText?: string
   ): Promise<boolean>;
   alert(text: string, title?: string, closeButtonText?: string): Promise<void>;
-  blockingDialog(text: string): DismissBlockingDialog
+  blockingDialog(text: string): DismissBlockingDialog | Promise<DismissBlockingDialog>;
 }

--- a/lib/services/api/messages.ts
+++ b/lib/services/api/messages.ts
@@ -31,6 +31,10 @@ export const OUTDATED_PROTOCOL_ALERT_TITLE         = 'Update Recommended';
 export const OUTDATED_PROTOCOL_ALERT_IGNORE        = 'Sign In';
 export const UPGRADING_ENCRYPTION                  = `Your account's encryption version is being upgraded. Do not close the application until this process completes.`;
 
+export const SETTING_PASSCODE                      = `Setting passcode. Do not close the application until this process completes.`;
+export const CHANGING_PASSCODE                     = `Changing passcode. Do not close the application until this process completes.`;
+export const REMOVING_PASSCODE                     = `Removing passcode. Do not close the application until this process completes.`;
+
 export function InsufficientPasswordMessage(minimum: number) {
   return `Your password must be at least ${minimum} characters in length. For your security, please choose a longer password or, ideally, a passphrase, and try again.`;
 }

--- a/lib/services/protocol_service.ts
+++ b/lib/services/protocol_service.ts
@@ -1019,7 +1019,7 @@ export class SNProtocolService extends PureService implements EncryptionDelegate
       this.keyMode !== KeyMode.WrapperOnly &&
       this.keyMode !== KeyMode.RootKeyPlusWrapper
     )) {
-      throw 'Attempting to remove root key wrapper on unwrapped key.';
+      throw Error('Attempting to remove root key wrapper on unwrapped key.');
     }
     if (this.keyMode === KeyMode.WrapperOnly) {
       this.keyMode = KeyMode.RootKeyNone;

--- a/lib/services/protocol_service.ts
+++ b/lib/services/protocol_service.ts
@@ -663,7 +663,7 @@ export class SNProtocolService extends PureService implements EncryptionDelegate
             const payloadVersion = encryptedPayload.version as ProtocolVersion;
             if (candidate) {
               itemsKey = CreateItemFromPayload(candidate) as SNItemsKey;
-            } 
+            }
             /**
              * Payloads with versions <= 003 use root key directly for encryption.
              */


### PR DESCRIPTION
Passcode operations can take some time. This change warns the user not to close the app during these destructive operations.