### PR TITLE
fix: do not activate or deactivate editors

### DIFF
--- a/dist/snjs.js
+++ b/dist/snjs.js
@@ -11666,6 +11666,10 @@ class component_manager_SNComponentManager extends pure_service["a" /* PureServi
       }
 
       for (const component of syncedComponents) {
+        if (component.isEditor()) {
+          continue;
+        }
+
         const isInActive = this.activeComponents[component.uuid];
 
         if (component.active && !component.deleted && !isInActive) {

--- a/dist/snjs.js
+++ b/dist/snjs.js
@@ -11667,6 +11667,7 @@ class component_manager_SNComponentManager extends pure_service["a" /* PureServi
 
       for (const component of syncedComponents) {
         if (component.isEditor()) {
+          /** Editors shouldn't get activated or deactivated */
           continue;
         }
 

--- a/lib/services/component_manager.ts
+++ b/lib/services/component_manager.ts
@@ -223,6 +223,9 @@ export class SNComponentManager extends PureService {
           }
         }
         for (const component of syncedComponents) {
+          if (component.isEditor()) {
+            continue;
+          }
           const isInActive = this.activeComponents[component.uuid];
           if (component.active && !component.deleted && !isInActive) {
             this.activateComponent(component.uuid);

--- a/lib/services/component_manager.ts
+++ b/lib/services/component_manager.ts
@@ -224,6 +224,7 @@ export class SNComponentManager extends PureService {
         }
         for (const component of syncedComponents) {
           if (component.isEditor()) {
+            /** Editors shouldn't get activated or deactivated */
             continue;
           }
           const isInActive = this.activeComponents[component.uuid];


### PR DESCRIPTION
It doesn't make sense to track an editor's `active/inactive` state but before this change it was still happening and could cause bugs when dealing with existing data.

@radko93 If you're using activate/deactivateComponent with editors I don't think it would cause an issue but you can't rely on their active/inactive state and should instead use ComponentManager.editorForNote(SNNote) to determine if an editor should be displayed