### PR TITLE
fix: session history tests

### DIFF
--- a/dist/snjs.js
+++ b/dist/snjs.js
@@ -17695,7 +17695,7 @@ class item_session_history_ItemSessionHistory {
 
       if (keep && isEntrySignificant(entry) && entry.operationVector() === -1) {
         /** This is a large negative change. Hang on to the previous entry. */
-        const previousEntry = this.entries[index - 1];
+        const previousEntry = this.entries[index + 1];
 
         if (previousEntry) {
           keepEntries.unshift(previousEntry);
@@ -17703,7 +17703,9 @@ class item_session_history_ItemSessionHistory {
       }
     };
 
-    this.entries.forEach((entry, index) => {
+    for (let index = this.entries.length; index--;) {
+      const entry = this.entries[index];
+
       if (index === 0 || index === this.entries.length - 1) {
         /** Keep the first and last */
         processEntry(entry, index, true);
@@ -17711,7 +17713,8 @@ class item_session_history_ItemSessionHistory {
         const significant = isEntrySignificant(entry);
         processEntry(entry, index, significant);
       }
-    });
+    }
+
     this.entries = this.entries.filter((entry, index) => {
       return keepEntries.indexOf(entry) !== -1;
     });

--- a/lib/services/history/session/item_session_history.ts
+++ b/lib/services/history/session/item_session_history.ts
@@ -73,7 +73,7 @@ export class ItemSessionHistory {
       }
       if (keep && isEntrySignificant(entry) && entry.operationVector() === -1) {
         /** This is a large negative change. Hang on to the previous entry. */
-        const previousEntry = this.entries[index - 1];
+        const previousEntry = this.entries[index + 1];
         if (previousEntry) {
           keepEntries.unshift(previousEntry);
         }

--- a/lib/services/history/session/item_session_history.ts
+++ b/lib/services/history/session/item_session_history.ts
@@ -79,7 +79,8 @@ export class ItemSessionHistory {
         }
       }
     };
-    this.entries.forEach((entry, index) => {
+    for (let index = this.entries.length; index--;) {
+      const entry = this.entries[index];
       if (index === 0 || index === this.entries.length - 1) {
         /** Keep the first and last */
         processEntry(entry, index, true);
@@ -87,7 +88,7 @@ export class ItemSessionHistory {
         const significant = isEntrySignificant(entry);
         processEntry(entry, index, significant);
       }
-    });
+    }
     this.entries = this.entries.filter((entry, index) => {
       return keepEntries.indexOf(entry) !== -1;
     });

--- a/test/history.test.js
+++ b/test/history.test.js
@@ -221,8 +221,8 @@ describe('history manager', () => {
         item = await setTextAndSync(
           this.application,
           item,
-          item.content.text + Factory.randomString(largeCharacterChange + 1
-        ));
+          item.content.text + Factory.randomString(largeCharacterChange + 1)
+        );
         expect(itemHistory.entries.length).to.equal(4);
       });
     


### PR DESCRIPTION
- [x] test session history entries order (should be from newest to oldest)
- [x] fix test "should optimize basic entries"
- [x] fix test "should keep the entry right before a large deletion, regardless of its delta"