### PR TITLE
fix: enforce correct type for getAllRawStorageKeyValues

### DIFF
--- a/dist/@types/device_interface.d.ts
+++ b/dist/@types/device_interface.d.ts
@@ -28,7 +28,10 @@ export declare abstract class DeviceInterface {
      * So we return the value as-is if JSON.parse throws an exception.
      */
     getJsonParsedStorageValue(key: string): Promise<any>;
-    abstract getAllRawStorageKeyValues(): Promise<Record<string, any>[]>;
+    abstract getAllRawStorageKeyValues(): Promise<{
+        key: string;
+        value: unknown;
+    }[]>;
     abstract setRawStorageValue(key: string, value: any): Promise<void>;
     abstract removeRawStorageValue(key: string): Promise<void>;
     abstract removeAllRawStorageValues(): Promise<void>;
@@ -42,7 +45,7 @@ export declare abstract class DeviceInterface {
     abstract openDatabase(): Promise<{
         isNewDatabase?: boolean;
     } | undefined>;
-    abstract getAllRawDatabasePayloads(): Promise<any[]>;
+    abstract getAllRawDatabasePayloads(): Promise<unknown[]>;
     abstract saveRawDatabasePayload(payload: any): Promise<void>;
     abstract saveRawDatabasePayloads(payloads: any[]): Promise<void>;
     abstract removeRawDatabasePayloadWithId(id: string): Promise<void>;

--- a/dist/@types/services/storage_service.d.ts
+++ b/dist/@types/services/storage_service.d.ts
@@ -87,7 +87,7 @@ export declare class SNStorageService extends PureService {
      * Clears simple values from storage only. Does not affect payloads.
      */
     clearValues(): Promise<void>;
-    getAllRawPayloads(): Promise<any[]>;
+    getAllRawPayloads(): Promise<unknown[]>;
     savePayload(payload: PurePayload): Promise<void>;
     savePayloads(decryptedPayloads: PurePayload[]): Promise<void>;
     deletePayloads(payloads: PurePayload[]): Promise<void>;

--- a/dist/@types/services/sync/sync_service.d.ts
+++ b/dist/@types/services/sync/sync_service.d.ts
@@ -113,7 +113,7 @@ export declare class SNSyncService extends PureService {
     /**
      * Used in tandem with `loadDatabasePayloads`
      */
-    getDatabasePayloads(): Promise<any[]>;
+    getDatabasePayloads(): Promise<unknown[]>;
     /**
      * @param rawPayloads - use `getDatabasePayloads` to get these payloads.
      * They are fed as a parameter so that callers don't have to await the loading, but can

--- a/lib/device_interface.ts
+++ b/lib/device_interface.ts
@@ -52,7 +52,7 @@ export abstract class DeviceInterface {
     }
   }
 
-  abstract async getAllRawStorageKeyValues() : Promise<Record<string, any>[]>;
+  abstract async getAllRawStorageKeyValues() : Promise<{ key: string, value: unknown }[]>;
 
   abstract async setRawStorageValue(key: string, value: any) : Promise<void>;
 
@@ -62,14 +62,14 @@ export abstract class DeviceInterface {
 
   /**
    * On web platforms, databased created may be new.
-   * New databases can be because of new sessions, or if the browser deleted it. 
+   * New databases can be because of new sessions, or if the browser deleted it.
    * In this case, callers should orchestrate with the server to redownload all items
    * from scratch.
    * @returns { isNewDatabase } - True if the database was newly created
    */
   abstract async openDatabase() : Promise<{ isNewDatabase?: boolean } | undefined>
 
-  abstract async getAllRawDatabasePayloads() : Promise<any[]>;
+  abstract async getAllRawDatabasePayloads() : Promise<unknown[]>;
 
   abstract async saveRawDatabasePayload(payload: any) : Promise<void>;
 


### PR DESCRIPTION
Because we've used `any` it was possible to return the wrong data format in `getAllRawStorageKeyValues`. This the type which web device interface actually returns and the one that is used in migrations.