### PR TITLE
fix: handle case where user may have 003 key not set as default

### DIFF
--- a/dist/@types/services/protocol_service.d.ts
+++ b/dist/@types/services/protocol_service.d.ts
@@ -358,7 +358,7 @@ export declare class SNProtocolService extends PureService implements Encryption
     /**
      * @returns The SNItemsKey object to use to encrypt new or updated items.
      */
-    getDefaultItemsKey(): SNItemsKey | undefined;
+    getDefaultItemsKey(): Promise<SNItemsKey | undefined>;
     /**
      * When the root key changes (non-null only), we must re-encrypt all items
      * keys with this new root key (by simply re-syncing).

--- a/dist/snjs.js
+++ b/dist/snjs.js
@@ -17324,7 +17324,7 @@ class protocol_service_SNProtocolService extends pure_service["a" /* PureService
 
   async handleFullSyncCompletion() {
     /** Always create a new items key after full sync, if no items key is found */
-    const currentItemsKey = this.getDefaultItemsKey();
+    const currentItemsKey = await this.getDefaultItemsKey();
 
     if (!currentItemsKey) {
       await this.createNewDefaultItemsKey();
@@ -17368,16 +17368,30 @@ class protocol_service_SNProtocolService extends pure_service["a" /* PureService
    */
 
 
-  getDefaultItemsKey() {
+  async getDefaultItemsKey() {
     const itemsKeys = this.latestItemsKeys();
 
     if (itemsKeys.length === 1) {
       return itemsKeys[0];
     }
 
-    return itemsKeys.find(key => {
+    const defaultKey = itemsKeys.find(key => {
       return key.isDefault;
     });
+    /**
+     * The default key appears to be either newer or older than the user's account version
+     * We could throw an exception here, but will instead fall back to a corrective action:
+     * return any items key that corresponds to the user's version
+     */
+
+    const userVersion = await this.getUserVersion();
+
+    if (userVersion && userVersion !== (defaultKey === null || defaultKey === void 0 ? void 0 : defaultKey.version)) {
+      console.warn("The user's default items key version is not equal to the account version.");
+      return itemsKeys.find(key => key.version === userVersion);
+    } else {
+      return defaultKey;
+    }
   }
   /**
    * When the root key changes (non-null only), we must re-encrypt all items
@@ -17440,7 +17454,7 @@ class protocol_service_SNProtocolService extends pure_service["a" /* PureService
       itemTemplate = await this.operatorForVersion(operatorVersion).createItemsKey();
     }
 
-    const currentDefault = this.getDefaultItemsKey();
+    const currentDefault = await this.getDefaultItemsKey();
 
     if (currentDefault) {
       await this.itemManager.changeItemsKey(currentDefault.uuid, mutator => {
@@ -17457,7 +17471,7 @@ class protocol_service_SNProtocolService extends pure_service["a" /* PureService
 
   async changePassword(email, currentPassword, newPassword, wrappingKey) {
     const [currentRootKey, currentKeyParams] = await Promise.all([this.getRootKey(), this.getRootKeyParams()]);
-    const currentDefaultItemsKey = this.getDefaultItemsKey();
+    const currentDefaultItemsKey = await this.getDefaultItemsKey();
     const computedRootKey = await this.computeRootKey(currentPassword, currentKeyParams);
 
     if (!currentRootKey.compare(computedRootKey)) {
@@ -22462,7 +22476,7 @@ class application_SNApplication {
     await this.syncService.sync({
       awaitAll: true
     });
-    const itemsKeyWasSynced = this.protocolService.getDefaultItemsKey().updated_at.getTime() > 0;
+    const itemsKeyWasSynced = (await this.protocolService.getDefaultItemsKey()).updated_at.getTime() > 0;
 
     if (!itemsKeyWasSynced) {
       await rollbackPasswordChange();

--- a/dist/snjs.js
+++ b/dist/snjs.js
@@ -17378,15 +17378,14 @@ class protocol_service_SNProtocolService extends pure_service["a" /* PureService
     const defaultKey = itemsKeys.find(key => {
       return key.isDefault;
     });
-    /**
-     * The default key appears to be either newer or older than the user's account version
-     * We could throw an exception here, but will instead fall back to a corrective action:
-     * return any items key that corresponds to the user's version
-     */
-
     const userVersion = await this.getUserVersion();
 
     if (userVersion && userVersion !== (defaultKey === null || defaultKey === void 0 ? void 0 : defaultKey.version)) {
+      /**
+       * The default key appears to be either newer or older than the user's account version
+       * We could throw an exception here, but will instead fall back to a corrective action:
+       * return any items key that corresponds to the user's version
+       */
       console.warn("The user's default items key version is not equal to the account version.");
       return itemsKeys.find(key => key.version === userVersion);
     } else {

--- a/lib/application.ts
+++ b/lib/application.ts
@@ -1139,7 +1139,7 @@ export class SNApplication {
 
     /** Sync the newly created items key. Roll back on failure */
     await this.syncService!.sync({ awaitAll: true });
-    const itemsKeyWasSynced = this.protocolService!.getDefaultItemsKey()!.updated_at.getTime() > 0;
+    const itemsKeyWasSynced = (await this.protocolService!.getDefaultItemsKey())!.updated_at.getTime() > 0;
     if (!itemsKeyWasSynced) {
       await rollbackPasswordChange();
       await this.syncService!.sync({ awaitAll: true });

--- a/lib/services/protocol_service.ts
+++ b/lib/services/protocol_service.ts
@@ -1273,7 +1273,7 @@ export class SNProtocolService extends PureService implements EncryptionDelegate
 
   private async handleFullSyncCompletion() {
     /** Always create a new items key after full sync, if no items key is found */
-    const currentItemsKey = this.getDefaultItemsKey();
+    const currentItemsKey = await this.getDefaultItemsKey();
     if (!currentItemsKey) {
       await this.createNewDefaultItemsKey();
       if (this.keyMode === KeyMode.WrapperOnly) {
@@ -1311,14 +1311,27 @@ export class SNProtocolService extends PureService implements EncryptionDelegate
   /**
    * @returns The SNItemsKey object to use to encrypt new or updated items.
    */
-  public getDefaultItemsKey() {
+  public async getDefaultItemsKey() {
     const itemsKeys = this.latestItemsKeys();
     if (itemsKeys.length === 1) {
       return itemsKeys[0];
     }
-    return itemsKeys.find((key) => {
+    const defaultKey = itemsKeys.find((key) => {
       return key.isDefault;
     });
+
+    /**
+     * The default key appears to be either newer or older than the user's account version
+     * We could throw an exception here, but will instead fall back to a corrective action:
+     * return any items key that corresponds to the user's version
+     */
+    const userVersion = await this.getUserVersion();
+    if(userVersion && userVersion !== defaultKey?.version) {
+      console.warn("The user's default items key version is not equal to the account version.");
+      return itemsKeys.find((key) => key.version === userVersion);
+    } else {
+      return defaultKey;
+    }
   }
 
   /**
@@ -1377,7 +1390,7 @@ export class SNProtocolService extends PureService implements EncryptionDelegate
       /** Create independent items key */
       itemTemplate = await this.operatorForVersion(operatorVersion).createItemsKey();
     }
-    const currentDefault = this.getDefaultItemsKey();
+    const currentDefault = await this.getDefaultItemsKey();
     if (currentDefault) {
       await this.itemManager!.changeItemsKey(
         currentDefault.uuid,
@@ -1411,7 +1424,7 @@ export class SNProtocolService extends PureService implements EncryptionDelegate
       this.getRootKey() as Promise<SNRootKey>,
       this.getRootKeyParams() as Promise<SNRootKeyParams>,
     ]);
-    const currentDefaultItemsKey = this.getDefaultItemsKey();
+    const currentDefaultItemsKey = await this.getDefaultItemsKey();
 
     const computedRootKey = await this.computeRootKey(
       currentPassword,

--- a/lib/services/protocol_service.ts
+++ b/lib/services/protocol_service.ts
@@ -1320,13 +1320,13 @@ export class SNProtocolService extends PureService implements EncryptionDelegate
       return key.isDefault;
     });
 
-    /**
-     * The default key appears to be either newer or older than the user's account version
-     * We could throw an exception here, but will instead fall back to a corrective action:
-     * return any items key that corresponds to the user's version
-     */
     const userVersion = await this.getUserVersion();
-    if(userVersion && userVersion !== defaultKey?.version) {
+    if (userVersion && userVersion !== defaultKey?.version) {
+      /**
+       * The default key appears to be either newer or older than the user's account version
+       * We could throw an exception here, but will instead fall back to a corrective action:
+       * return any items key that corresponds to the user's version
+       */
       console.warn("The user's default items key version is not equal to the account version.");
       return itemsKeys.find((key) => key.version === userVersion);
     } else {

--- a/test/keys.test.js
+++ b/test/keys.test.js
@@ -145,7 +145,7 @@ describe('keys', () => {
 
   it('items key should be encrypted with root key', async function () {
     await Factory.registerUserToApplication({ application: this.application });
-    const itemsKey = this.application.protocolService.getDefaultItemsKey();
+    const itemsKey = await this.application.protocolService.getDefaultItemsKey();
     /** Encrypt items key */
     const encryptedPayload = await this.application.protocolService.payloadByEncryptingPayload(
       itemsKey.payloadRepresentation(),
@@ -311,7 +311,7 @@ describe('keys', () => {
        * Upon signing into an 003 account, the application should delete any neverSynced items keys,
        * and create a new default items key that is the default for a given protocol version.
        */
-      const defaultItemsKey = this.application.protocolService.getDefaultItemsKey();
+      const defaultItemsKey = await this.application.protocolService.getDefaultItemsKey();
       const latestVersion = this.application.protocolService.getLatestVersion();
       expect(defaultItemsKey.version).to.equal(latestVersion);
 
@@ -425,7 +425,7 @@ describe('keys', () => {
     });
     const itemsKeys = this.application.itemManager.itemsKeys();
     expect(itemsKeys.length).to.equal(1);
-    const defaultItemsKey = this.application.protocolService.getDefaultItemsKey();
+    const defaultItemsKey = await this.application.protocolService.getDefaultItemsKey();
 
     await this.application.changePassword(
       this.password,
@@ -433,7 +433,7 @@ describe('keys', () => {
     );
 
     expect(this.application.itemManager.itemsKeys().length).to.equal(2);
-    const newDefaultItemsKey = this.application.protocolService.getDefaultItemsKey();
+    const newDefaultItemsKey = await this.application.protocolService.getDefaultItemsKey();
     expect(newDefaultItemsKey.uuid).to.not.equal(defaultItemsKey.uuid);
   }).timeout(5000);
 });

--- a/test/upgrading.test.js
+++ b/test/upgrading.test.js
@@ -221,7 +221,7 @@ describe('upgrading', () => {
 
   it('protocol version should be upgraded on password change', async function () {
     /** Delete default items key that is created on launch */
-    const itemsKey = this.application.protocolService.getDefaultItemsKey();
+    const itemsKey = await this.application.protocolService.getDefaultItemsKey();
     await this.application.itemManager.setItemToBeDeleted(itemsKey.uuid);
     expect(this.application.itemManager.itemsKeys().length).to.equal(0);
 
@@ -266,7 +266,7 @@ describe('upgrading', () => {
       (await this.application.protocolService.getRootKey()).version
     ).to.equal(latestVersion);
 
-    const defaultItemsKey = this.application.protocolService.getDefaultItemsKey();
+    const defaultItemsKey = await this.application.protocolService.getDefaultItemsKey();
     expect(defaultItemsKey.version).to.equal(latestVersion);
 
     /** After change, note should now be encrypted with latest protocol version */


### PR DESCRIPTION
I'm not sure how my 003 account got into a state where it had a single itemsKey, but isDefault was not set to true. So upon sign in to the account, when the application attempted to persist data locally, it searched for any key where isDefault is true, and that key was an ephemeral 004 key that the application created on launch.

This ephemeral items key still existed because the full sync had not completed yet, otherwise, it would have been deleted at that point. But because we persist to storage incrementally, it was still a valid key available to SNJS.

It seems like we should be able to perform [this](https://github.com/standardnotes/snjs/blob/004/lib/services/protocol_service.ts#L1230) step on incremental sync as well, not just full syncs. The reason I'm applying this as a mostly corrective fix for now is that I'm not sure how my account got into this state and it may very well be due to fluxes in the development environment. If we find that the console.warn added in this PR occurs often, we'll need to investigate how accounts get into that state.