### PR TITLE
fix: use raw keychain value before migration

### DIFF
--- a/dist/snjs.js
+++ b/dist/snjs.js
@@ -14817,7 +14817,7 @@ class _2020_01_15_Migration20200115 extends Migration {
       [ValueModesKeys.Unwrapped]: {},
       [ValueModesKeys.Wrapped]: {}
     };
-    const keychainValue = await this.services.deviceInterface.getNamespacedKeychainValue();
+    const keychainValue = await this.services.deviceInterface.getRawKeychainValue();
     const biometricPrefs = await this.services.deviceInterface.getJsonParsedStorageValue(LegacyKeys.MobileBiometricsPrefs);
 
     if (biometricPrefs) {

--- a/lib/migrations/2020-01-15.ts
+++ b/lib/migrations/2020-01-15.ts
@@ -309,7 +309,7 @@ export class Migration20200115 extends Migration {
       [ValueModesKeys.Wrapped]: {},
     };
 
-    const keychainValue = await this.services.deviceInterface.getNamespacedKeychainValue();
+    const keychainValue = await this.services.deviceInterface.getRawKeychainValue();
 
     const biometricPrefs = await this.services.deviceInterface.getJsonParsedStorageValue(
       LegacyKeys.MobileBiometricsPrefs


### PR DESCRIPTION
Before data is migrated keychain data is in the old format.