### PR TITLE
fix: prevent importing new backup file into old account

### DIFF
--- a/dist/@types/protocol/versions.d.ts
+++ b/dist/@types/protocol/versions.d.ts
@@ -9,6 +9,6 @@ export declare enum ProtocolVersion {
 /**
  *  -1 if a < b
  *  0 if a == b
- *  1 is a > b
+ *  1 if a > b
  */
 export declare function compareVersions(a: ProtocolVersion, b: ProtocolVersion): number;

--- a/dist/@types/services/api/messages.d.ts
+++ b/dist/@types/services/api/messages.d.ts
@@ -26,3 +26,4 @@ export declare const DO_NOT_CLOSE_APPLICATION = "Do not close the application un
 export declare function InsufficientPasswordMessage(minimum: number): string;
 export declare function StrictSignInFailed(current: ProtocolVersion, latest: ProtocolVersion): string;
 export declare const UNSUPPORTED_BACKUP_FILE_VERSION = "This backup file was created using a newer version of the application and cannot be imported here. Please update your application and try again.";
+export declare const BACKUP_FILE_MORE_RECENT_THAN_ACCOUNT = "This backup file was created using a newer encryption version than your account's. Please run the available encryption upgrade and try again.";

--- a/lib/protocol/versions.ts
+++ b/lib/protocol/versions.ts
@@ -10,7 +10,7 @@ export enum ProtocolVersion {
 /**
  *  -1 if a < b
  *  0 if a == b
- *  1 is a > b
+ *  1 if a > b
  */
 export function compareVersions(a: ProtocolVersion, b: ProtocolVersion) {
   const aNum = Number(a);

--- a/lib/services/api/messages.ts
+++ b/lib/services/api/messages.ts
@@ -45,4 +45,5 @@ export function StrictSignInFailed(current: ProtocolVersion, latest: ProtocolVer
   return `Strict Sign In has refused the server's sign-in parameters. The latest account version is ${latest}, but the server is reporting a version of ${current} for your account. If you'd like to proceed with sign in anyway, please disable Strict Sign In and try again.`;
 }
 
-export const UNSUPPORTED_BACKUP_FILE_VERSION = `This backup file was created using a newer version of the application and cannot be imported here. Please update your application and try again.`
+export const UNSUPPORTED_BACKUP_FILE_VERSION = `This backup file was created using a newer version of the application and cannot be imported here. Please update your application and try again.`;
+export const BACKUP_FILE_MORE_RECENT_THAN_ACCOUNT = `This backup file was created using a newer encryption version than your account's. Please run the available encryption upgrade and try again.`;

--- a/lib/services/protocol_service.ts
+++ b/lib/services/protocol_service.ts
@@ -224,7 +224,7 @@ export class SNProtocolService extends PureService implements EncryptionDelegate
    */
   public async getUserVersion() {
     const keyParams = await this.getAccountKeyParams();
-    return keyParams && keyParams.version;
+    return keyParams?.version;
   }
 
   /**

--- a/test/model_tests/importing.test.js
+++ b/test/model_tests/importing.test.js
@@ -28,6 +28,20 @@ describe('importing', () => {
     expect(result.error).to.exist;
   });
 
+  it('should not import backups made from 004 into 003 account', async function () {
+    await Factory.registerOldUser({
+      ...this,
+      version: ProtocolVersion.V003,
+    });
+    const result = await this.application.importData(
+      {
+        version: ProtocolVersion.V004,
+        items: []
+      }
+    );
+    expect(result.error).to.exist;
+  });
+
   it('importing existing data should keep relationships valid', async function () {
     const pair = Factory.createRelatedNoteTagPairPayload();
     const notePayload = pair[0];


### PR DESCRIPTION
We already prevent importing a backup from an unsupported protocol version, but we also need to prevent importing backups from known version into older accounts.