### PR TITLE
refactor: decrypt payloads concurrently

### DIFF
--- a/dist/@types/utils.d.ts
+++ b/dist/@types/utils.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 import { AnyRecord } from './types';
-export declare function getGlobalScope(): (Window & typeof globalThis) | NodeJS.Global | null;
+export declare function getGlobalScope(): (Window & typeof globalThis) | (NodeJS.Global & typeof globalThis) | null;
 export declare function dictToArray<T>(dict: Record<any, T>): NonNullable<T>[];
 /**
  * Whether we are in a web browser

--- a/dist/snjs.js
+++ b/dist/snjs.js
@@ -16658,10 +16658,10 @@ class protocol_service_SNProtocolService extends pure_service["a" /* PureService
 
 
   async payloadsByDecryptingPayloads(payloads, key) {
-    const decryptItem = async item => {
-      if (!item) {
+    const decryptItem = async encryptedPayload => {
+      if (!encryptedPayload) {
         /** Keep in-counts similar to out-counts */
-        return item;
+        return encryptedPayload;
       }
       /**
        * We still want to decrypt deleted payloads if they have content in case
@@ -16669,17 +16669,17 @@ class protocol_service_SNProtocolService extends pure_service["a" /* PureService
        */
 
 
-      if (item.deleted === true && Object(utils["p" /* isNullOrUndefined */])(item.content)) {
-        return item;
+      if (encryptedPayload.deleted === true && Object(utils["p" /* isNullOrUndefined */])(encryptedPayload.content)) {
+        return encryptedPayload;
       }
 
-      const isDecryptable = Object(utils["s" /* isString */])(item.content);
+      const isDecryptable = Object(utils["s" /* isString */])(encryptedPayload.content);
 
       if (!isDecryptable) {
-        return item;
+        return encryptedPayload;
       }
 
-      return this.payloadByDecryptingPayload(item, key);
+      return this.payloadByDecryptingPayload(encryptedPayload, key);
     };
 
     return Promise.all(payloads.map(payload => decryptItem(payload)));

--- a/lib/services/protocol_service.ts
+++ b/lib/services/protocol_service.ts
@@ -566,24 +566,24 @@ export class SNProtocolService extends PureService implements EncryptionDelegate
    * Similar to `payloadByDecryptingPayload`, but operates on an array of payloads.
    */
   public async payloadsByDecryptingPayloads(payloads: PurePayload[], key?: SNRootKey | SNItemsKey) {
-    const decryptItem = async (item: PurePayload) => {
-      if (!item) {
+    const decryptItem = async (encryptedPayload: PurePayload) => {
+      if (!encryptedPayload) {
         /** Keep in-counts similar to out-counts */
-        return item;
+        return encryptedPayload;
       }
       /**
        * We still want to decrypt deleted payloads if they have content in case
        * they were marked as dirty but not yet synced.
        */
-      if (item.deleted === true && isNullOrUndefined(item.content)) {
-        return item;
+      if (encryptedPayload.deleted === true && isNullOrUndefined(encryptedPayload.content)) {
+        return encryptedPayload;
       }
-      const isDecryptable = isString(item.content);
+      const isDecryptable = isString(encryptedPayload.content);
       if (!isDecryptable) {
-       return item;
+       return encryptedPayload;
       }
       return this.payloadByDecryptingPayload(
-        item,
+        encryptedPayload,
         key
       );
     }


### PR DESCRIPTION
Seems like right now the bottleneck of decrypt performance might be "The Bridge" in React Native. I wanted to try to decrypt items concurrently and it improved performance by a significant amount (30% up to 50% using my test data). Problem with React Native bridge is that there is turnaround time, so waiting for every promise to return might not be the best option. I haven't tested all error scenarios yet with this.