### PR TITLE
Fix/app unlock subheading

### DIFF
--- a/dist/@types/challenges.d.ts
+++ b/dist/@types/challenges.d.ts
@@ -33,7 +33,7 @@ export declare class Challenge {
     /** Inside of the modal, this is the H1 */
     get heading(): string;
     /** Inside of the modal, this is the H2 */
-    get subheading(): string;
+    get subheading(): string | undefined;
     hasPromptForValidationType(type: ChallengeValidation): boolean;
 }
 /**

--- a/dist/snjs.js
+++ b/dist/snjs.js
@@ -11309,6 +11309,9 @@ class challenges_Challenge {
       case ChallengeReason.Migration:
         return ChallengeStrings.EnterPasscodeForMigration;
 
+      case ChallengeReason.ApplicationUnlock:
+        return undefined;
+
       default:
         throw Error('No subheading available for custom challenge. Pass subheading to the constructor.');
     }

--- a/lib/challenges.ts
+++ b/lib/challenges.ts
@@ -77,6 +77,8 @@ export class Challenge {
     switch (this.reason) {
       case ChallengeReason.Migration:
         return ChallengeStrings.EnterPasscodeForMigration;
+      case ChallengeReason.ApplicationUnlock:
+        return undefined;
       default:
         throw Error('No subheading available for custom challenge. Pass subheading to the constructor.')
     }


### PR DESCRIPTION
App unlock prompts do not have a subheading, so SNJS should not throw an error.
cc @radko93 