### PR TITLE
feat: duplicate item content overrides

### DIFF
--- a/dist/@types/application.d.ts
+++ b/dist/@types/application.d.ts
@@ -211,6 +211,7 @@ export declare class SNApplication {
     referencesForItem(item: SNItem, contentType?: ContentType): SNItem[];
     /** Returns items referencing an item */
     referencingForItem(item: SNItem, contentType?: ContentType): SNItem[];
+    duplicateItem<T extends SNItem>(item: T, additionalContent?: Partial<PayloadContent>): Promise<T>;
     findTagByTitle(title: string): SNTag | undefined;
     findOrCreateTag(title: string): Promise<SNTag>;
     getSmartTags(): SNSmartTag[];

--- a/dist/@types/protocol/payloads/functions.d.ts
+++ b/dist/@types/protocol/payloads/functions.d.ts
@@ -1,10 +1,11 @@
+import { PayloadContent } from './generator';
 import { ImmutablePayloadCollection } from "../collection/payload_collection";
 import { PurePayload } from './pure_payload';
 /**
  * Copies payload and assigns it a new uuid.
  * @returns An array of payloads that have changed as a result of copying.
  */
-export declare function PayloadsByDuplicating(payload: PurePayload, baseCollection: ImmutablePayloadCollection, isConflict: boolean): Promise<PurePayload[]>;
+export declare function PayloadsByDuplicating(payload: PurePayload, baseCollection: ImmutablePayloadCollection, isConflict: boolean, additionalContent?: Partial<PayloadContent>): Promise<PurePayload[]>;
 /**
  * Return the payloads that result if you alternated the uuid for the payload.
  * Alternating a UUID involves instructing related items to drop old references of a uuid

--- a/dist/@types/services/item_manager.d.ts
+++ b/dist/@types/services/item_manager.d.ts
@@ -142,7 +142,7 @@ export declare class ItemManager extends PureService {
      * Duplicates an item and maps it, thus propagating the item to observers.
      * @param isConflict - Whether to mark the duplicate as a conflict of the original.
      */
-    duplicateItem(uuid: UuidString, isConflict?: boolean): Promise<SNItem>;
+    duplicateItem<T extends SNItem>(uuid: UuidString, isConflict?: boolean, additionalContent?: Partial<PayloadContent>): Promise<T>;
     /**
      * Creates an item and conditionally maps it and marks it as dirty.
      * @param needsSync - Whether to mark the item as needing sync

--- a/dist/snjs.js
+++ b/dist/snjs.js
@@ -11466,7 +11466,7 @@ const AffectorMapping = {
  * @returns An array of payloads that have changed as a result of copying.
  */
 
-async function PayloadsByDuplicating(payload, baseCollection, isConflict) {
+async function PayloadsByDuplicating(payload, baseCollection, isConflict, additionalContent) {
   const results = [];
   const override = {
     uuid: await uuid_Uuid.GenerateUuid(),
@@ -11476,11 +11476,10 @@ async function PayloadsByDuplicating(payload, baseCollection, isConflict) {
     lastSyncEnd: null,
     duplicate_of: payload.uuid
   };
+  override.content = functions_objectSpread(functions_objectSpread({}, payload.safeContent), additionalContent);
 
   if (isConflict) {
-    override.content = functions_objectSpread(functions_objectSpread({}, payload.safeContent), {}, {
-      conflict_of: payload.uuid
-    });
+    override.content.conflict_of = payload.uuid;
   }
 
   const copy = Object(generator["b" /* CopyPayload */])(payload, override);
@@ -20754,9 +20753,10 @@ class item_manager_ItemManager extends pure_service["a" /* PureService */] {
 
   async duplicateItem(uuid) {
     let isConflict = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
+    let additionalContent = arguments.length > 2 ? arguments[2] : undefined;
     const item = this.findItem(uuid);
     const payload = Object(generator["e" /* CreateMaxPayloadFromAnyObject */])(item);
-    const resultingPayloads = await PayloadsByDuplicating(payload, this.modelManager.getMasterCollection(), isConflict);
+    const resultingPayloads = await PayloadsByDuplicating(payload, this.modelManager.getMasterCollection(), isConflict, additionalContent);
     await this.modelManager.emitPayloads(resultingPayloads, sources["a" /* PayloadSource */].LocalChanged);
     const duplicate = this.findItem(resultingPayloads[0].uuid);
     return duplicate;
@@ -23473,6 +23473,12 @@ class application_SNApplication {
     }
 
     return references;
+  }
+
+  duplicateItem(item, additionalContent) {
+    const duplicate = this.itemManager.duplicateItem(item.uuid, false, additionalContent);
+    this.sync();
+    return duplicate;
   }
 
   findTagByTitle(title) {

--- a/lib/application.ts
+++ b/lib/application.ts
@@ -646,6 +646,19 @@ export class SNApplication {
     return references as SNItem[];
   }
 
+  public duplicateItem<T extends SNItem>(
+    item: T,
+    additionalContent?: Partial<PayloadContent>
+  ) {
+    const duplicate = this.itemManager.duplicateItem<T>(
+      item.uuid,
+      false,
+      additionalContent
+    );
+    this.sync();
+    return duplicate;
+  }
+
   public findTagByTitle(title: string) {
     return this.itemManager!.findTagByTitle(title);
   }

--- a/lib/protocol/payloads/functions.ts
+++ b/lib/protocol/payloads/functions.ts
@@ -1,6 +1,6 @@
 import { MutationType } from './../../models/core/item';
 import { SNComponent, ComponentArea, ComponentMutator } from './../../models/app/component';
-import { ContentReference } from './generator';
+import { ContentReference, PayloadContent } from './generator';
 import { ImmutablePayloadCollection } from "@Protocol/collection/payload_collection";
 import { CreateItemFromPayload } from '@Models/generator';
 import remove from 'lodash/remove';
@@ -49,8 +49,9 @@ const AffectorMapping = {
 export async function PayloadsByDuplicating(
   payload: PurePayload,
   baseCollection: ImmutablePayloadCollection,
-  isConflict: boolean
-  ) {
+  isConflict: boolean,
+  additionalContent?: Partial<PayloadContent>
+) {
   const results = [];
   const override: PayloadOverride = {
     uuid: await Uuid.GenerateUuid(),
@@ -60,11 +61,12 @@ export async function PayloadsByDuplicating(
     lastSyncEnd: null,
     duplicate_of: payload.uuid,
   };
+  override.content = {
+    ...payload.safeContent,
+    ...additionalContent,
+  }
   if (isConflict) {
-    override.content = {
-      ...payload.safeContent,
-      conflict_of: payload.uuid,
-    };
+    override.content.conflict_of = payload.uuid;
   }
   const copy = CopyPayload(
     payload,

--- a/lib/services/item_manager.ts
+++ b/lib/services/item_manager.ts
@@ -545,20 +545,25 @@ export class ItemManager extends PureService {
    * Duplicates an item and maps it, thus propagating the item to observers.
    * @param isConflict - Whether to mark the duplicate as a conflict of the original.
    */
-  public async duplicateItem(uuid: UuidString, isConflict = false) {
+  public async duplicateItem<T extends SNItem>(
+    uuid: UuidString,
+    isConflict = false,
+    additionalContent?: Partial<PayloadContent>
+  ) {
     const item = this.findItem(uuid)!;
     const payload = CreateMaxPayloadFromAnyObject(item);
     const resultingPayloads = await PayloadsByDuplicating(
       payload,
       this.modelManager!.getMasterCollection(),
       isConflict,
+      additionalContent
     );
     await this.modelManager!.emitPayloads(
       resultingPayloads,
       PayloadSource.LocalChanged
     );
     const duplicate = this.findItem(resultingPayloads[0].uuid!);
-    return duplicate!;
+    return duplicate! as T;
   }
 
   /**


### PR DESCRIPTION
Expose ItemManager.duplicateItems to clients and let them specify content overrides (useful for restoring item revisions as copies or duplicating notes in the future)

Also adds test to ensure a duplicated note keeps its editors and tags.