### PR TITLE
refactor: main auth completion handler should be responsible for setting root key

### DIFF
--- a/dist/@types/application.d.ts
+++ b/dist/@types/application.d.ts
@@ -311,16 +311,6 @@ export declare class SNApplication {
      */
     deinit(source: DeinitSource): void;
     /**
-     * Returns the wrapping key for operations that require resaving the root key
-     * (changing the account password, signing in, registering, or upgrading protocol)
-     * Returns empty object if no passcode is configured.
-     * Otherwise returns {cancled: true} if the operation is canceled, or
-     * {wrappingKey} with the result.
-     * @param passcode - If the consumer already has access to the passcode,
-     * they can pass it here so that the user is not prompted again.
-     */
-    private getWrappingKeyIfNecessary;
-    /**
      *  @param mergeLocal  Whether to merge existing offline data into account. If false,
      *                     any pre-existing data will be fully deleted upon success.
      */
@@ -330,7 +320,14 @@ export declare class SNApplication {
      * If false, any pre-existing data will be fully deleted upon success.
      */
     signIn(email: string, password: string, strict?: boolean, ephemeral?: boolean, mergeLocal?: boolean, awaitSync?: boolean): Promise<import("./services/api/responses").HttpResponse>;
-    changePassword(currentPassword: string, newPassword: string, origination?: KeyParamsOrigination, { validatePasswordStrength }?: {
+    /**
+     * @param passcode - Changing the account password requires the local
+     * passcode if configured (to rewrap the account key with passcode). If the passcode
+     * is not passed in, the user will be prompted for the passcode. However if the consumer
+     * already has reference to the passcode, they can pass it in here so that the user
+     * is not prompted again.
+     */
+    changePassword(currentPassword: string, newPassword: string, passcode?: string, origination?: KeyParamsOrigination, { validatePasswordStrength }?: {
         validatePasswordStrength?: boolean | undefined;
     }): Promise<{
         error?: {

--- a/dist/@types/application.d.ts
+++ b/dist/@types/application.d.ts
@@ -324,24 +324,13 @@ export declare class SNApplication {
      *  @param mergeLocal  Whether to merge existing offline data into account. If false,
      *                     any pre-existing data will be fully deleted upon success.
      */
-    register(email: string, password: string, ephemeral?: boolean, mergeLocal?: boolean): Promise<import("./services/api/responses").HttpResponse | {
-        error: Error;
-    }>;
+    register(email: string, password: string, ephemeral?: boolean, mergeLocal?: boolean): Promise<import("./services/api/responses").HttpResponse>;
     /**
      * @param mergeLocal  Whether to merge existing offline data into account.
      * If false, any pre-existing data will be fully deleted upon success.
      */
-    signIn(email: string, password: string, strict?: boolean, ephemeral?: boolean, mergeLocal?: boolean, awaitSync?: boolean): Promise<import("./services/api/responses").HttpResponse | {
-        error: Error;
-    }>;
-    /**
-     * @param passcode - Changing the account password requires the local
-     * passcode if configured (to rewrap the account key with passcode). If the passcode
-     * is not passed in, the user will be prompted for the passcode. However if the consumer
-     * already has referene to the passcode, they can pass it in here so that the user
-     * is not prompted again.
-     */
-    changePassword(currentPassword: string, newPassword: string, passcode?: string, origination?: KeyParamsOrigination, { validatePasswordStrength }?: {
+    signIn(email: string, password: string, strict?: boolean, ephemeral?: boolean, mergeLocal?: boolean, awaitSync?: boolean): Promise<import("./services/api/responses").HttpResponse>;
+    changePassword(currentPassword: string, newPassword: string, origination?: KeyParamsOrigination, { validatePasswordStrength }?: {
         validatePasswordStrength?: boolean | undefined;
     }): Promise<{
         error?: {

--- a/dist/@types/protocol/root_key.d.ts
+++ b/dist/@types/protocol/root_key.d.ts
@@ -31,7 +31,11 @@ export declare class SNRootKey extends SNItem {
      */
     get itemsKey(): any;
     get masterKey(): any;
-    get serverPassword(): any;
+    /**
+     * serverPassword is not persisted as part of keychainValue, so if loaded from disk,
+     * this value may be undefined.
+     */
+    get serverPassword(): string | undefined;
     /** 003 and below only. */
     get dataAuthenticationKey(): any;
     /**

--- a/dist/@types/services/api/api_service.d.ts
+++ b/dist/@types/services/api/api_service.d.ts
@@ -1,5 +1,5 @@
 import { UuidString } from './../../types';
-import { ChangePasswordResponse, HttpResponse, KeyParamsResponse, RegistrationResponse, RevisionListEntry, RevisionListResponse, SessionRenewalResponse, SignInResponse, SingleRevisionResponse } from './responses';
+import { ChangePasswordResponse, HttpResponse, HttpStatusCode, KeyParamsResponse, RegistrationResponse, RevisionListEntry, RevisionListResponse, SessionRenewalResponse, SignInResponse, SingleRevisionResponse } from './responses';
 import { Session } from './session';
 import { ContentType } from '../../models/content_types';
 import { PurePayload } from '../../protocol/payloads/pure_payload';
@@ -35,7 +35,7 @@ export declare class SNApiService extends PureService {
     getSession(): Session | undefined;
     private path;
     private params;
-    createErrorResponse(message: string): HttpResponse;
+    createErrorResponse(message: string, status?: HttpStatusCode): HttpResponse;
     private errorResponseWithFallbackMessage;
     /**
      * @param mfaKeyPath  The params path the server expects for authentication against

--- a/dist/@types/services/api/messages.d.ts
+++ b/dist/@types/services/api/messages.d.ts
@@ -33,6 +33,9 @@ export declare const PasswordChangeStrings: {
     PasscodeRequired: string;
     Failed: string;
 };
+export declare const RegisterStrings: {
+    PasscodeRequired: string;
+};
 export declare const SignInStrings: {
     PasscodeRequired: string;
     IncorrectMfa: string;

--- a/dist/@types/services/api/messages.d.ts
+++ b/dist/@types/services/api/messages.d.ts
@@ -31,6 +31,7 @@ export declare const UNSUPPORTED_BACKUP_FILE_VERSION = "This backup file was cre
 export declare const BACKUP_FILE_MORE_RECENT_THAN_ACCOUNT = "This backup file was created using a newer encryption version than your account's. Please run the available encryption upgrade and try again.";
 export declare const PasswordChangeStrings: {
     PasscodeRequired: string;
+    Failed: string;
 };
 export declare const SignInStrings: {
     PasscodeRequired: string;

--- a/dist/@types/services/api/responses.d.ts
+++ b/dist/@types/services/api/responses.d.ts
@@ -8,7 +8,8 @@ export declare enum HttpStatusCode {
     /** The session's access token is expired, but the refresh token is valid */
     HttpStatusExpiredAccessToken = 498,
     /** The session's access token and refresh token are expired, user must reauthenticate */
-    HttpStatusInvalidSession = 401
+    HttpStatusInvalidSession = 401,
+    LocalValidationError = 10
 }
 export declare type HttpResponse = {
     status: HttpStatusCode;

--- a/dist/@types/services/api/session_manager.d.ts
+++ b/dist/@types/services/api/session_manager.d.ts
@@ -5,7 +5,7 @@ import { SNProtocolService } from './../protocol_service';
 import { SNApiService } from './api_service';
 import { SNStorageService } from './../storage_service';
 import { SNRootKey } from '../../protocol/root_key';
-import { SNRootKeyParams, AnyKeyParamsContent } from './../../protocol/key_params';
+import { AnyKeyParamsContent } from './../../protocol/key_params';
 import { PureService } from '../pure_service';
 import { SNAlertService } from '../alert_service';
 export declare const MINIMUM_PASSWORD_LENGTH = 8;
@@ -48,8 +48,8 @@ export declare class SNSessionManager extends PureService<SessionEvent> {
     private retrieveKeyParams;
     signIn(email: string, password: string, strict?: boolean, minAllowedVersion?: ProtocolVersion): Promise<SessionManagerResponse>;
     private performSignIn;
-    bypassChecksAndSignInWithServerPassword(email: string, serverPassword: string, mfaKeyPath?: string, mfaCode?: string): Promise<SignInResponse>;
-    changePassword(currentServerPassword: string, newServerPassword: string, newKeyParams: SNRootKeyParams): Promise<SessionManagerResponse>;
+    bypassChecksAndSignInWithRootKey(email: string, rootKey: SNRootKey, mfaKeyPath?: string, mfaCode?: string): Promise<SignInResponse>;
+    changePassword(currentServerPassword: string, newRootKey: SNRootKey): Promise<SessionManagerResponse>;
     getSessionsList(): Promise<HttpResponse>;
     private handleSuccessAuthResponse;
 }

--- a/dist/@types/services/api/session_manager.d.ts
+++ b/dist/@types/services/api/session_manager.d.ts
@@ -49,7 +49,7 @@ export declare class SNSessionManager extends PureService<SessionEvent> {
     signIn(email: string, password: string, strict?: boolean, minAllowedVersion?: ProtocolVersion): Promise<SessionManagerResponse>;
     private performSignIn;
     bypassChecksAndSignInWithRootKey(email: string, rootKey: SNRootKey, mfaKeyPath?: string, mfaCode?: string): Promise<SignInResponse>;
-    changePassword(currentServerPassword: string, newRootKey: SNRootKey): Promise<SessionManagerResponse>;
+    changePassword(currentServerPassword: string, newRootKey: SNRootKey, wrappingKey?: SNRootKey): Promise<SessionManagerResponse>;
     getSessionsList(): Promise<HttpResponse>;
     private handleSuccessAuthResponse;
 }

--- a/dist/@types/services/challenge/challenge_service.d.ts
+++ b/dist/@types/services/challenge/challenge_service.d.ts
@@ -1,3 +1,4 @@
+import { SNRootKey } from './../../protocol/root_key';
 import { SNProtocolService } from "../protocol_service";
 import { SNStorageService } from "../storage_service";
 import { PureService } from "../pure_service";
@@ -18,8 +19,8 @@ export declare type ChallengeObserver = {
  * The challenge service creates, updates and keeps track of running challenge operations.
  */
 export declare class ChallengeService extends PureService {
-    private storageService?;
-    private protocolService?;
+    private storageService;
+    private protocolService;
     private challengeOperations;
     sendChallenge?: (challenge: Challenge) => void;
     private challengeObservers;
@@ -39,6 +40,7 @@ export declare class ChallengeService extends PureService {
         passcode: string;
         canceled: boolean;
     }>;
+    getWrappingKeyIfApplicable(requireCorrect?: boolean): Promise<SNRootKey | undefined>;
     isPasscodeLocked(): Promise<boolean>;
     hasBiometricsEnabled(): Promise<boolean>;
     enableBiometrics(): Promise<void>;

--- a/dist/@types/services/challenge/challenge_service.d.ts
+++ b/dist/@types/services/challenge/challenge_service.d.ts
@@ -40,7 +40,25 @@ export declare class ChallengeService extends PureService {
         passcode: string;
         canceled: boolean;
     }>;
-    getWrappingKeyIfApplicable(requireCorrect?: boolean): Promise<SNRootKey | undefined>;
+    /**
+     * Returns the wrapping key for operations that require resaving the root key
+     * (changing the account password, signing in, registering, or upgrading protocol)
+     * Returns empty object if no passcode is configured.
+     * Otherwise returns {cancled: true} if the operation is canceled, or
+     * {wrappingKey} with the result.
+     * @param passcode - If the consumer already has access to the passcode,
+     * they can pass it here so that the user is not prompted again.
+     */
+    getWrappingKeyIfApplicable(passcode?: string): Promise<{
+        canceled?: undefined;
+        wrappingKey?: undefined;
+    } | {
+        canceled: boolean;
+        wrappingKey?: undefined;
+    } | {
+        wrappingKey: SNRootKey;
+        canceled?: undefined;
+    }>;
     isPasscodeLocked(): Promise<boolean>;
     hasBiometricsEnabled(): Promise<boolean>;
     enableBiometrics(): Promise<void>;

--- a/dist/@types/services/key_recovery_service.d.ts
+++ b/dist/@types/services/key_recovery_service.d.ts
@@ -1,29 +1,14 @@
 import { SNSyncService } from './sync/sync_service';
 import { ApplicationStage } from './../stages';
 import { SNStorageService } from './storage_service';
-import { SNRootKeyParams } from './../protocol/key_params';
 import { SNSessionManager } from './api/session_manager';
 import { PayloadManager } from './model_manager';
 import { SNAlertService } from './alert_service';
 import { ChallengeService } from './challenge/challenge_service';
-import { SNRootKey } from '../protocol/root_key';
 import { SNProtocolService } from './protocol_service';
 import { SNApiService } from './api/api_service';
-import { SNItemsKey } from './../models/app/items_key';
 import { ItemManager } from './item_manager';
 import { PureService } from './pure_service';
-declare type DecryptionCallback = (key: SNItemsKey, result: DecryptionResponse) => void;
-declare type DecryptionResponse = {
-    success: boolean;
-    rootKey?: SNRootKey;
-};
-declare type DecryptionQueueItem = {
-    key: SNItemsKey;
-    keyParams: SNRootKeyParams;
-    callback?: DecryptionCallback;
-    promise?: Promise<DecryptionResponse>;
-    resolve?: (result: DecryptionResponse) => void;
-};
 export declare class SNKeyRecoveryService extends PureService {
     private itemManager;
     private modelManager;
@@ -56,27 +41,21 @@ export declare class SNKeyRecoveryService extends PureService {
      * When the app first launches, we will query the isolated storage to see if there are any
      * keys we need to decrypt.
      */
-    handleIgnoredItemsKeys(keys: SNItemsKey[], persistIncoming?: boolean): Promise<void>;
-    handleUndecryptableItemsKeys(keys: SNItemsKey[]): Promise<void>;
+    private handleIgnoredItemsKeys;
+    private handleUndecryptableItemsKeys;
     processPersistedUndecryptables(): Promise<void>;
     private getUndecryptables;
     private persistUndecryptables;
     private saveToUndecryptables;
     private removeFromUndecryptables;
-    get queuePromise(): Promise<(DecryptionResponse | undefined)[]>;
-    getClientKeyParams(): Promise<SNRootKeyParams | undefined>;
-    serverKeyParamsAreSafe(clientParams: SNRootKeyParams): boolean;
-    performServerSignIn(keyParams: SNRootKeyParams): Promise<void>;
-    /**
-     * When we've successfully validated a root key that matches server params,
-     * we replace our current client root key with the newly generated key
-     */
-    replaceClientRootKey(rootKey: SNRootKey): Promise<void>;
-    getWrappingKeyIfApplicable(): Promise<SNRootKey | undefined>;
-    addKeysToQueue(keys: SNItemsKey[], callback?: DecryptionCallback): Promise<void>;
-    readdQueueItem(queueItem: DecryptionQueueItem): void;
+    private get queuePromise();
+    private getClientKeyParams;
+    private serverKeyParamsAreSafe;
+    private performServerSignIn;
+    private getWrappingKeyIfApplicable;
+    private addKeysToQueue;
+    private readdQueueItem;
     private beginProcessingQueue;
-    popQueueItem(queueItem: DecryptionQueueItem): Promise<void>;
-    popQueueForKeyParams(keyParams: SNRootKeyParams): DecryptionQueueItem[];
+    private popQueueItem;
+    private popQueueForKeyParams;
 }
-export {};

--- a/dist/@types/services/protocol_service.d.ts
+++ b/dist/@types/services/protocol_service.d.ts
@@ -278,7 +278,7 @@ export declare class SNProtocolService extends PureService implements Encryption
      * @param wrappingKey If a passcode is configured, the wrapping key
      * must be supplied, so that the new root key can be wrapped with the wrapping key.
      */
-    setNewRootKey(key: SNRootKey, wrappingKey?: SNRootKey): Promise<void>;
+    setRootKey(key: SNRootKey, wrappingKey?: SNRootKey): Promise<void>;
     /**
      * Returns the in-memory root key value.
      */
@@ -377,11 +377,6 @@ export declare class SNProtocolService extends PureService implements Encryption
      * and its .itemsKey value should be equal to the root key masterKey value.
      */
     private createNewDefaultItemsKey;
-    changePassword(email: string, currentPassword: string, newPassword: string, wrappingKey?: SNRootKey, origination?: KeyParamsOrigination): Promise<[Error | null, {
-        currentServerPassword: string;
-        newRootKey: SNRootKey;
-        newKeyParams: SNRootKeyParams;
-        rollback: () => Promise<void>;
-    }?]>;
+    createNewItemsKeyWithRollback(): Promise<() => Promise<void>>;
 }
 export {};

--- a/dist/snjs.js
+++ b/dist/snjs.js
@@ -12699,17 +12699,6 @@ class key_recovery_service_SNKeyRecoveryService extends pure_service["a" /* Pure
       return this.performServerSignIn(keyParams);
     }
   }
-  /**
-   * When we've successfully validated a root key that matches server params,
-   * we replace our current client root key with the newly generated key
-   */
-
-
-  async replaceClientRootKey(rootKey) {
-    const wrappingKey = await this.getWrappingKeyIfApplicable();
-    await this.protocolService.setRootKey(rootKey, wrappingKey);
-    this.alertService.alert(KeyRecoveryStrings.KeyRecoveryRootKeyReplaced);
-  }
 
   async getWrappingKeyIfApplicable() {
     if (!this.protocolService.hasPasscode()) {
@@ -12874,7 +12863,9 @@ class key_recovery_service_SNKeyRecoveryService extends pure_service["a" /* Pure
 
       if (replacesRootKey) {
         /** Replace our root key with the generated root key */
-        await this.replaceClientRootKey(rootKey);
+        const wrappingKey = await this.getWrappingKeyIfApplicable();
+        await this.protocolService.setRootKey(rootKey, wrappingKey);
+        this.alertService.alert(KeyRecoveryStrings.KeyRecoveryRootKeyReplaced);
       } else {
         this.alertService.alert(KeyRecoveryStrings.KeyRecoveryKeyRecovered);
       }

--- a/lib/protocol/root_key.ts
+++ b/lib/protocol/root_key.ts
@@ -102,7 +102,11 @@ export class SNRootKey extends SNItem {
     return this.payload.safeContent.masterKey;
   }
 
-  public get serverPassword() {
+  /**
+   * serverPassword is not persisted as part of keychainValue, so if loaded from disk,
+   * this value may be undefined.
+   */
+  public get serverPassword(): string | undefined {
     return this.payload.safeContent.serverPassword;
   }
 
@@ -121,7 +125,7 @@ export class SNRootKey extends SNItem {
     const hasServerPassword = this.serverPassword && otherKey.serverPassword;
     return (
       timingSafeEqual(this.masterKey, otherKey.masterKey) &&
-      (!hasServerPassword || timingSafeEqual(this.serverPassword, otherKey.serverPassword))
+      (!hasServerPassword || timingSafeEqual(this.serverPassword!, otherKey.serverPassword!))
     );
   }
 

--- a/lib/services/api/api_service.ts
+++ b/lib/services/api/api_service.ts
@@ -125,8 +125,8 @@ export class SNApiService extends PureService {
     return params;
   }
 
-  public createErrorResponse(message: string) {
-    return { error: { message: message } } as HttpResponse;
+  public createErrorResponse(message: string, status?: HttpStatusCode) {
+    return { error: { message, status } } as HttpResponse;
   }
 
   private errorResponseWithFallbackMessage(

--- a/lib/services/api/messages.ts
+++ b/lib/services/api/messages.ts
@@ -52,7 +52,8 @@ export const UNSUPPORTED_BACKUP_FILE_VERSION = `This backup file was created usi
 export const BACKUP_FILE_MORE_RECENT_THAN_ACCOUNT = `This backup file was created using a newer encryption version than your account's. Please run the available encryption upgrade and try again.`;
 
 export const PasswordChangeStrings = {
-  PasscodeRequired: 'Your passcode is required to process your password change.'
+  PasscodeRequired: 'Your passcode is required to process your password change.',
+  Failed: 'Unable to change your password due to a sync error. Please try again.',
 }
 
 export const SignInStrings = {

--- a/lib/services/api/messages.ts
+++ b/lib/services/api/messages.ts
@@ -56,6 +56,10 @@ export const PasswordChangeStrings = {
   Failed: 'Unable to change your password due to a sync error. Please try again.',
 }
 
+export const RegisterStrings = {
+  PasscodeRequired: 'Your passcode is required in order to register for an account.',
+}
+
 export const SignInStrings = {
   PasscodeRequired: 'Your passcode is required in order to sign in to your account.',
   IncorrectMfa: 'Incorrect two-factor authentication code. Please try again.',

--- a/lib/services/api/responses.ts
+++ b/lib/services/api/responses.ts
@@ -10,6 +10,7 @@ export enum HttpStatusCode {
   HttpStatusExpiredAccessToken = 498,
   /** The session's access token and refresh token are expired, user must reauthenticate */
   HttpStatusInvalidSession = 401,
+  LocalValidationError = 10
 }
 
 export type HttpResponse = {

--- a/lib/services/key_recovery_service.ts
+++ b/lib/services/key_recovery_service.ts
@@ -147,7 +147,7 @@ export class SNKeyRecoveryService extends PureService {
    * When the app first launches, we will query the isolated storage to see if there are any
    * keys we need to decrypt.
    */
-  async handleIgnoredItemsKeys(keys: SNItemsKey[], persistIncoming = true) {
+  private async handleIgnoredItemsKeys(keys: SNItemsKey[], persistIncoming = true) {
     /**
      * Persist the keys locally in isolated storage, so that if we don't properly decrypt
      * them in this app session, the user has a chance to later. If there already exists
@@ -167,7 +167,7 @@ export class SNKeyRecoveryService extends PureService {
     await this.beginProcessingQueue();
   }
 
-  async handleUndecryptableItemsKeys(keys: SNItemsKey[]) {
+  private async handleUndecryptableItemsKeys(keys: SNItemsKey[]) {
     await this.addKeysToQueue(keys);
     await this.beginProcessingQueue();
   }
@@ -216,22 +216,22 @@ export class SNKeyRecoveryService extends PureService {
     await this.persistUndecryptables(record);
   }
 
-  get queuePromise() {
+  private get queuePromise() {
     return Promise.all(this.decryptionQueue.map(q => q.promise));
   }
 
-  async getClientKeyParams() {
+  private async getClientKeyParams() {
     return this.protocolService.getAccountKeyParams();
   }
 
-  serverKeyParamsAreSafe(clientParams: SNRootKeyParams) {
+  private serverKeyParamsAreSafe(clientParams: SNRootKeyParams) {
     return leftVersionGreaterThanOrEqualToRight(
       this.serverParams!.version,
       clientParams.version
     );
   }
 
-  async performServerSignIn(keyParams: SNRootKeyParams): Promise<void> {
+  private async performServerSignIn(keyParams: SNRootKeyParams): Promise<void> {
     /** Get the user's account password */
     const challenge = new Challenge(
       [
@@ -275,22 +275,7 @@ export class SNKeyRecoveryService extends PureService {
     }
   }
 
-  /**
-   * When we've successfully validated a root key that matches server params,
-   * we replace our current client root key with the newly generated key
-   */
-  async replaceClientRootKey(rootKey: SNRootKey): Promise<void> {
-    const wrappingKey = await this.getWrappingKeyIfApplicable();
-    await this.protocolService.setRootKey(
-      rootKey,
-      wrappingKey
-    );
-    this.alertService.alert(
-      KeyRecoveryStrings.KeyRecoveryRootKeyReplaced
-    );
-  }
-
-  async getWrappingKeyIfApplicable(): Promise<SNRootKey | undefined> {
+  private async getWrappingKeyIfApplicable(): Promise<SNRootKey | undefined> {
     if (!this.protocolService.hasPasscode()) {
       return undefined;
     }
@@ -307,7 +292,7 @@ export class SNKeyRecoveryService extends PureService {
     return wrappingKey;
   }
 
-  async addKeysToQueue(keys: SNItemsKey[], callback?: DecryptionCallback) {
+  private async addKeysToQueue(keys: SNItemsKey[], callback?: DecryptionCallback) {
     for (const key of keys) {
       const keyParams = await this.protocolService.getKeyEmbeddedKeyParams(key);
       if (!keyParams) {
@@ -326,7 +311,7 @@ export class SNKeyRecoveryService extends PureService {
     }
   }
 
-  readdQueueItem(queueItem: DecryptionQueueItem) {
+  private readdQueueItem(queueItem: DecryptionQueueItem) {
     const promise: Promise<DecryptionResponse> = new Promise((resolve) => {
       queueItem.resolve = resolve;
     });
@@ -376,10 +361,9 @@ export class SNKeyRecoveryService extends PureService {
         this.syncService.sync({ checkIntegrity: true });
       }
     })
-
   }
 
-  async popQueueItem(queueItem: DecryptionQueueItem): Promise<void> {
+  private async popQueueItem(queueItem: DecryptionQueueItem): Promise<void> {
     if (!queueItem.resolve) {
       throw Error('Attempting to pop queue element with no resolve function');
     }
@@ -462,7 +446,14 @@ export class SNKeyRecoveryService extends PureService {
       await this.storageService.savePayloads(allRelevantKeyPayloads);
       if (replacesRootKey) {
         /** Replace our root key with the generated root key */
-        await this.replaceClientRootKey(rootKey);
+        const wrappingKey = await this.getWrappingKeyIfApplicable();
+        await this.protocolService.setRootKey(
+          rootKey,
+          wrappingKey
+        );
+        this.alertService.alert(
+          KeyRecoveryStrings.KeyRecoveryRootKeyReplaced
+        );
       } else {
         this.alertService.alert(
           KeyRecoveryStrings.KeyRecoveryKeyRecovered
@@ -485,7 +476,7 @@ export class SNKeyRecoveryService extends PureService {
     }
   }
 
-  popQueueForKeyParams(keyParams: SNRootKeyParams) {
+  private popQueueForKeyParams(keyParams: SNRootKeyParams) {
     const matching = [];
     const nonmatching = [];
     for (const queueItem of this.decryptionQueue) {

--- a/lib/services/protocol_service.ts
+++ b/lib/services/protocol_service.ts
@@ -1026,7 +1026,7 @@ export class SNProtocolService extends PureService implements EncryptionDelegate
     const wrappedKey = await this.payloadByEncryptingPayload(
       payload,
       EncryptionIntent.LocalStorageEncrypted,
-      wrappingKey,
+      wrappingKey
     );
     await this.storageService!.setValue(
       StorageKey.WrappedRootKey,

--- a/test/key_recovery_service.test.js
+++ b/test/key_recovery_service.test.js
@@ -318,7 +318,7 @@ describe('key recovery service', function () {
       unassociatedPassword,
       KeyParamsOrigination.Registration
     );
-    await application.protocolService.setNewRootKey(randomRootKey);
+    await application.protocolService.setRootKey(randomRootKey);
     const correctItemsKey = await application.protocolService.defaultOperator().createItemsKey();
     const encrypted = await application.protocolService.payloadByEncryptingPayload(
       correctItemsKey.payload,

--- a/test/keys.test.js
+++ b/test/keys.test.js
@@ -95,7 +95,7 @@ describe('keys', function () {
     const email = 'foo';
     const password = 'bar';
     const key = await this.application.protocolService.createRootKey(email, password, KeyParamsOrigination.Registration);
-    this.application.protocolService.setNewRootKey(key);
+    this.application.protocolService.setRootKey(key);
 
     const payload = CreateMaxPayloadFromAnyObject(
       {
@@ -120,7 +120,7 @@ describe('keys', function () {
       password,
       KeyParamsOrigination.Registration
     );
-    await this.application.protocolService.setNewRootKey(key);
+    await this.application.protocolService.setRootKey(key);
     await this.application.setPasscode(password);
 
     /** We should be able to decrypt wrapped root key with passcode */
@@ -139,7 +139,7 @@ describe('keys', function () {
         newPassword,
         KeyParamsOrigination.Registration
         );
-    await this.application.protocolService.setNewRootKey(
+    await this.application.protocolService.setRootKey(
       newKey,
       wrappingKey
     );

--- a/test/lib/factory.js
+++ b/test/lib/factory.js
@@ -98,10 +98,7 @@ export async function registerOldUser({ application, email, password, version })
     accountKey.serverPassword,
     accountKey.keyParams
   );
-  await application.sessionManager.handleSuccessAuthResponse(response);
-  await application.protocolService.setNewRootKey(
-    accountKey
-  );
+  await application.sessionManager.handleSuccessAuthResponse(response, accountKey);
   application.notifyEvent(ApplicationEvent.SignedIn);
   await application.syncService.sync({
     mode: SyncModes.DownloadFirst,

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -187,7 +187,7 @@ describe('server session', function () {
       this.password,
       this.newPassword
     );
-    expect(changePasswordResponse.error.message).to.equal('Could not connect to server.');
+    expect(changePasswordResponse.error.message).to.equal('Invalid login credentials.');
 
     expectFactoryException();
     const loginResponse = await Factory.loginToApplication({
@@ -211,7 +211,7 @@ describe('server session', function () {
     );
 
     expect(changePasswordResponse).to.be.ok;
-    expect(changePasswordResponse.error.message).to.equal('Could not connect to server.');
+    expect(changePasswordResponse.error.message).to.equal('Invalid login credentials.');
 
     expectFactoryException();
     const loginResponseWithNewPassword = await Factory.loginToApplication({
@@ -388,6 +388,8 @@ describe('server session', function () {
       password: password
     });
 
+    const oldRootKey = await appA.protocolService.getRootKey();
+
     /** Set the session as nonsense */
     appA.apiService.session.accessToken = 'foo';
     appA.apiService.session.refreshToken = 'bar';
@@ -401,6 +403,10 @@ describe('server session', function () {
     expect(didPromptForSignIn).to.equal(true);
     expect(appA.apiService.session.accessToken).to.not.equal('foo');
     expect(appA.apiService.session.refreshToken).to.not.equal('bar');
+
+    /** Expect that the session recovery replaces the global root key */
+    const newRootKey = await appA.protocolService.getRootKey();
+    expect(oldRootKey).to.not.equal(newRootKey);
 
     appA.deinit();
   });

--- a/test/upgrading.test.js
+++ b/test/upgrading.test.js
@@ -239,7 +239,7 @@ describe('upgrading', () => {
     });
 
     it('rolls back the local protocol upgrade if the server responds with an error', async function () {
-      sinon.replace(this.application.protocolService, 'changePassword', async () => ([Error()]));
+      sinon.replace(this.application.sessionManager, 'changePassword', async () => ([Error()]));
 
       this.application.setLaunchCallback({
         receiveChallenge: this.receiveChallenge


### PR DESCRIPTION
- Fixes issue where setting the root key on sign in/register would also call encryptAllItemsKeys (should only be called on password change)
- Fixes issue where performing a sign in through detached session recovery wouldn't set global root key. This is fixed via the fact that the main sign in function (through the auth completion handler) now sets the root key directly, as opposed to letting callers be responsible for this.