### PR TITLE
fix: update missing uuid error with content type

### DIFF
--- a/lib/protocol/payloads/pure_payload.ts
+++ b/lib/protocol/payloads/pure_payload.ts
@@ -72,7 +72,7 @@ export class PurePayload {
     }
     this.uuid = rawPayload.uuid!;
     if (!this.uuid && this.fields.includes(PayloadField.Uuid)) {
-      throw Error('uuid is null, yet this payloads fields indicate it shouldnt be. Content type: ', rawPayload.content_type);
+      throw Error(`uuid is null, yet this payloads fields indicate it shouldnt be. Content type: ${rawPayload.content_type}`);
     }
     this.content_type = rawPayload.content_type!;
     if (rawPayload.content) {

--- a/lib/protocol/payloads/pure_payload.ts
+++ b/lib/protocol/payloads/pure_payload.ts
@@ -72,7 +72,7 @@ export class PurePayload {
     }
     this.uuid = rawPayload.uuid!;
     if (!this.uuid && this.fields.includes(PayloadField.Uuid)) {
-      throw Error('uuid is null, yet this payloads fields indicate it shouldnt be.');
+      throw Error('uuid is null, yet this payloads fields indicate it shouldnt be. Content type: ', rawPayload.content_type);
     }
     this.content_type = rawPayload.content_type!;
     if (rawPayload.content) {


### PR DESCRIPTION
When we have errors reported there we don't know what types of items fail. This will make it easier to debug errors.