### PR TITLE
fix: initialize theme display options

### DIFF
--- a/dist/snjs.js
+++ b/dist/snjs.js
@@ -20617,6 +20617,7 @@ class item_manager_ItemManager extends pure_service["a" /* PureService */] {
     this.collection.setDisplayOptions(content_types["a" /* ContentType */].Tag, CollectionSort.Title, 'asc');
     this.collection.setDisplayOptions(content_types["a" /* ContentType */].ItemsKey, CollectionSort.CreatedAt, 'asc');
     this.collection.setDisplayOptions(content_types["a" /* ContentType */].Component, CollectionSort.CreatedAt, 'asc');
+    this.collection.setDisplayOptions(content_types["a" /* ContentType */].Theme, CollectionSort.Title, 'asc');
     this.collection.setDisplayOptions(content_types["a" /* ContentType */].SmartTag, CollectionSort.Title, 'asc');
     this.notesView = new item_collection_notes_view_ItemCollectionNotesView(this.collection);
   }

--- a/lib/services/item_manager.ts
+++ b/lib/services/item_manager.ts
@@ -80,6 +80,7 @@ export class ItemManager extends PureService {
     this.collection.setDisplayOptions(ContentType.Tag, CollectionSort.Title, 'asc');
     this.collection.setDisplayOptions(ContentType.ItemsKey, CollectionSort.CreatedAt, 'asc');
     this.collection.setDisplayOptions(ContentType.Component, CollectionSort.CreatedAt, 'asc');
+    this.collection.setDisplayOptions(ContentType.Theme, CollectionSort.Title, 'asc');
     this.collection.setDisplayOptions(ContentType.SmartTag, CollectionSort.Title, 'asc');
     this.notesView = new ItemCollectionNotesView(this.collection);
   }


### PR DESCRIPTION
When resetting local data (Like before signing in without merging with local data) uninitialized theme display options would cause errors