### PR TITLE
fix: do not attempt to sign in again when canceling MFA prompt

### DIFF
--- a/dist/@types/services/api/api_service.d.ts
+++ b/dist/@types/services/api/api_service.d.ts
@@ -1,5 +1,5 @@
 import { UuidString } from './../../types';
-import { ChangePasswordResponse, HttpResponse, HttpStatusCode, KeyParamsResponse, RegistrationResponse, RevisionListEntry, RevisionListResponse, SessionRenewalResponse, SignInResponse, SingleRevisionResponse } from './responses';
+import { ChangePasswordResponse, HttpResponse, StatusCode, KeyParamsResponse, RegistrationResponse, RevisionListEntry, RevisionListResponse, SessionRenewalResponse, SignInResponse, SingleRevisionResponse } from './responses';
 import { Session } from './session';
 import { ContentType } from '../../models/content_types';
 import { PurePayload } from '../../protocol/payloads/pure_payload';
@@ -35,7 +35,7 @@ export declare class SNApiService extends PureService {
     getSession(): Session | undefined;
     private path;
     private params;
-    createErrorResponse(message: string, status?: HttpStatusCode): HttpResponse;
+    createErrorResponse(message: string, status?: StatusCode): HttpResponse;
     private errorResponseWithFallbackMessage;
     /**
      * @param mfaKeyPath  The params path the server expects for authentication against

--- a/dist/@types/services/api/responses.d.ts
+++ b/dist/@types/services/api/responses.d.ts
@@ -2,17 +2,18 @@ import { RawPayload } from '../../protocol/payloads/generator';
 import { ApiEndpointParam } from './keys';
 import { KeyParamsOrigination, AnyKeyParamsContent } from './../../protocol/key_params';
 import { ProtocolVersion } from './../../protocol/versions';
-export declare enum HttpStatusCode {
+export declare enum StatusCode {
     HttpStatusMinSuccess = 200,
     HttpStatusMaxSuccess = 299,
     /** The session's access token is expired, but the refresh token is valid */
     HttpStatusExpiredAccessToken = 498,
     /** The session's access token and refresh token are expired, user must reauthenticate */
     HttpStatusInvalidSession = 401,
-    LocalValidationError = 10
+    LocalValidationError = 10,
+    CanceledMfa = 11
 }
 export declare type HttpResponse = {
-    status: HttpStatusCode;
+    status: StatusCode;
     error?: {
         message: string;
         status: number;

--- a/dist/snjs.js
+++ b/dist/snjs.js
@@ -13005,22 +13005,23 @@ var ApiEndpointParam;
 ;
 // CONCATENATED MODULE: ./lib/services/api/responses.ts
 
-var HttpStatusCode;
+var StatusCode;
 
-(function (HttpStatusCode) {
-  HttpStatusCode[HttpStatusCode["HttpStatusMinSuccess"] = 200] = "HttpStatusMinSuccess";
-  HttpStatusCode[HttpStatusCode["HttpStatusMaxSuccess"] = 299] = "HttpStatusMaxSuccess";
+(function (StatusCode) {
+  StatusCode[StatusCode["HttpStatusMinSuccess"] = 200] = "HttpStatusMinSuccess";
+  StatusCode[StatusCode["HttpStatusMaxSuccess"] = 299] = "HttpStatusMaxSuccess";
   /** The session's access token is expired, but the refresh token is valid */
 
-  HttpStatusCode[HttpStatusCode["HttpStatusExpiredAccessToken"] = 498] = "HttpStatusExpiredAccessToken";
+  StatusCode[StatusCode["HttpStatusExpiredAccessToken"] = 498] = "HttpStatusExpiredAccessToken";
   /** The session's access token and refresh token are expired, user must reauthenticate */
 
-  HttpStatusCode[HttpStatusCode["HttpStatusInvalidSession"] = 401] = "HttpStatusInvalidSession";
-  HttpStatusCode[HttpStatusCode["LocalValidationError"] = 10] = "LocalValidationError";
-})(HttpStatusCode || (HttpStatusCode = {}));
+  StatusCode[StatusCode["HttpStatusInvalidSession"] = 401] = "HttpStatusInvalidSession";
+  StatusCode[StatusCode["LocalValidationError"] = 10] = "LocalValidationError";
+  StatusCode[StatusCode["CanceledMfa"] = 11] = "CanceledMfa";
+})(StatusCode || (StatusCode = {}));
 
 function isErrorResponseExpiredToken(errorResponse) {
-  return errorResponse.status === HttpStatusCode.HttpStatusExpiredAccessToken;
+  return errorResponse.status === StatusCode.HttpStatusExpiredAccessToken;
 }
 var ConflictType;
 
@@ -13373,7 +13374,7 @@ class session_manager_SNSessionManager extends pure_service["a" /* PureService *
 
     if (canceled) {
       return {
-        response: this.apiService.createErrorResponse(RegisterStrings.PasscodeRequired, HttpStatusCode.LocalValidationError)
+        response: this.apiService.createErrorResponse(RegisterStrings.PasscodeRequired, StatusCode.LocalValidationError)
       };
     }
 
@@ -13410,7 +13411,7 @@ class session_manager_SNSessionManager extends pure_service["a" /* PureService *
         if (!inputtedCode) {
           /** User dismissed window without input */
           return {
-            response: this.apiService.createErrorResponse(SignInStrings.SignInCanceledMissingMfa)
+            response: this.apiService.createErrorResponse(SignInStrings.SignInCanceledMissingMfa, StatusCode.CanceledMfa)
           };
         }
 
@@ -13445,7 +13446,7 @@ class session_manager_SNSessionManager extends pure_service["a" /* PureService *
     let minAllowedVersion = arguments.length > 3 ? arguments[3] : undefined;
     const result = await this.performSignIn(email, password, strict, minAllowedVersion);
 
-    if (result.response.error && result.response.error.status !== HttpStatusCode.LocalValidationError) {
+    if (result.response.error && result.response.error.status !== StatusCode.LocalValidationError && result.response.error.status !== StatusCode.CanceledMfa) {
       /**
        * Try signing in with trimmed + lowercase version of email
        */
@@ -13535,7 +13536,7 @@ class session_manager_SNSessionManager extends pure_service["a" /* PureService *
     } = await this.challengeService.getWrappingKeyIfApplicable();
 
     if (canceled) {
-      return this.apiService.createErrorResponse(SignInStrings.PasscodeRequired, HttpStatusCode.LocalValidationError);
+      return this.apiService.createErrorResponse(SignInStrings.PasscodeRequired, StatusCode.LocalValidationError);
     }
 
     const signInResponse = await this.apiService.signIn(email, rootKey.serverPassword, mfaKeyPath, mfaCode);
@@ -13558,7 +13559,7 @@ class session_manager_SNSessionManager extends pure_service["a" /* PureService *
 
         if (!inputtedCode) {
           /** User dismissed window without input */
-          return this.apiService.createErrorResponse(SignInStrings.SignInCanceledMissingMfa);
+          return this.apiService.createErrorResponse(SignInStrings.SignInCanceledMissingMfa, StatusCode.CanceledMfa);
         }
 
         return this.bypassChecksAndSignInWithRootKey(email, rootKey, signInResponse.error.payload.mfa_key, inputtedCode);
@@ -13702,7 +13703,7 @@ class http_service_SNHttpService extends pure_service["a" /* PureService */] {
       Object.assign(response, body);
     } catch (error) {}
 
-    if (httpStatus >= HttpStatusCode.HttpStatusMinSuccess && httpStatus <= HttpStatusCode.HttpStatusMaxSuccess) {
+    if (httpStatus >= StatusCode.HttpStatusMinSuccess && httpStatus <= StatusCode.HttpStatusMaxSuccess) {
       resolve(response);
     } else {
       if (!response.error) {
@@ -14124,7 +14125,7 @@ class api_service_SNApiService extends pure_service["a" /* PureService */] {
 
 
   preprocessAuthenticatedErrorResponse(response) {
-    if (response.status === HttpStatusCode.HttpStatusInvalidSession && this.session) {
+    if (response.status === StatusCode.HttpStatusInvalidSession && this.session) {
       var _this$invalidSessionO;
 
       (_this$invalidSessionO = this.invalidSessionObserver) === null || _this$invalidSessionO === void 0 ? void 0 : _this$invalidSessionO.call(this);

--- a/lib/services/api/api_service.ts
+++ b/lib/services/api/api_service.ts
@@ -2,7 +2,7 @@ import { UuidString } from './../../types';
 import {
   ChangePasswordResponse,
   HttpResponse,
-  HttpStatusCode,
+  StatusCode,
   isErrorResponseExpiredToken,
   KeyParamsResponse,
   RegistrationResponse,
@@ -125,7 +125,7 @@ export class SNApiService extends PureService {
     return params;
   }
 
-  public createErrorResponse(message: string, status?: HttpStatusCode) {
+  public createErrorResponse(message: string, status?: StatusCode) {
     return { error: { message, status } } as HttpResponse;
   }
 
@@ -462,7 +462,7 @@ export class SNApiService extends PureService {
 
   /** Handle errored responses to authenticated requests */
   private preprocessAuthenticatedErrorResponse(response: HttpResponse) {
-    if (response.status === HttpStatusCode.HttpStatusInvalidSession && this.session) {
+    if (response.status === StatusCode.HttpStatusInvalidSession && this.session) {
       this.invalidSessionObserver?.();
     }
   }

--- a/lib/services/api/http_service.ts
+++ b/lib/services/api/http_service.ts
@@ -1,6 +1,6 @@
 import { UNKNOWN_ERROR } from './messages';
 import { PureService } from '@Lib/services/pure_service';
-import { HttpResponse, HttpStatusCode } from './responses';
+import { HttpResponse, StatusCode } from './responses';
 
 export enum HttpVerb {
   Get = 'get',
@@ -104,8 +104,8 @@ export class SNHttpService extends PureService {
       response.object = body;
       Object.assign(response, body);
     } catch (error) { }
-    if ((httpStatus >= HttpStatusCode.HttpStatusMinSuccess
-      && httpStatus <= HttpStatusCode.HttpStatusMaxSuccess)) {
+    if ((httpStatus >= StatusCode.HttpStatusMinSuccess
+      && httpStatus <= StatusCode.HttpStatusMaxSuccess)) {
       resolve(response);
     } else {
       if (!response.error) {

--- a/lib/services/api/responses.ts
+++ b/lib/services/api/responses.ts
@@ -3,18 +3,20 @@ import { ApiEndpointParam } from './keys';
 import { KeyParamsOrigination, AnyKeyParamsContent } from './../../protocol/key_params';
 import { ProtocolVersion } from './../../protocol/versions';
 
-export enum HttpStatusCode {
+export enum StatusCode {
   HttpStatusMinSuccess = 200,
   HttpStatusMaxSuccess = 299,
   /** The session's access token is expired, but the refresh token is valid */
   HttpStatusExpiredAccessToken = 498,
   /** The session's access token and refresh token are expired, user must reauthenticate */
   HttpStatusInvalidSession = 401,
-  LocalValidationError = 10
+
+  LocalValidationError = 10,
+  CanceledMfa = 11,
 }
 
 export type HttpResponse = {
-  status: HttpStatusCode,
+  status: StatusCode,
   error?: {
     message: string,
     status: number,
@@ -29,7 +31,7 @@ export type HttpResponse = {
 }
 
 export function isErrorResponseExpiredToken(errorResponse: HttpResponse) {
-  return errorResponse.status === HttpStatusCode.HttpStatusExpiredAccessToken;
+  return errorResponse.status === StatusCode.HttpStatusExpiredAccessToken;
 }
 
 type SessionBody = {

--- a/lib/services/api/session_manager.ts
+++ b/lib/services/api/session_manager.ts
@@ -14,7 +14,7 @@ import {
   ChangePasswordResponse,
   HttpResponse,
   KeyParamsResponse,
-  HttpStatusCode
+  StatusCode
 } from './responses';
 import { SNProtocolService } from './../protocol_service';
 import { SNApiService } from './api_service';
@@ -212,7 +212,7 @@ export class SNSessionManager extends PureService<SessionEvent> {
       return {
         response: this.apiService.createErrorResponse(
           RegisterStrings.PasscodeRequired,
-          HttpStatusCode.LocalValidationError
+          StatusCode.LocalValidationError
         )
       };
     }
@@ -263,7 +263,10 @@ export class SNSessionManager extends PureService<SessionEvent> {
         if (!inputtedCode) {
           /** User dismissed window without input */
           return {
-            response: this.apiService.createErrorResponse(SignInStrings.SignInCanceledMissingMfa)
+            response: this.apiService.createErrorResponse(
+              SignInStrings.SignInCanceledMissingMfa,
+              StatusCode.CanceledMfa
+            )
           };
         }
         return this.retrieveKeyParams(
@@ -297,7 +300,11 @@ export class SNSessionManager extends PureService<SessionEvent> {
       strict,
       minAllowedVersion
     );
-    if (result.response.error && result.response.error.status !== HttpStatusCode.LocalValidationError) {
+    if (
+      result.response.error &&
+      result.response.error.status !== StatusCode.LocalValidationError &&
+      result.response.error.status !== StatusCode.CanceledMfa
+    ) {
       /**
        * Try signing in with trimmed + lowercase version of email
        */
@@ -400,7 +407,7 @@ export class SNSessionManager extends PureService<SessionEvent> {
     if (canceled) {
       return this.apiService.createErrorResponse(
         SignInStrings.PasscodeRequired,
-        HttpStatusCode.LocalValidationError
+        StatusCode.LocalValidationError
       );
     }
     const signInResponse = await this.apiService.signIn(
@@ -422,7 +429,10 @@ export class SNSessionManager extends PureService<SessionEvent> {
         const inputtedCode = await this.promptForMfaValue();
         if (!inputtedCode) {
           /** User dismissed window without input */
-          return this.apiService.createErrorResponse(SignInStrings.SignInCanceledMissingMfa);
+          return this.apiService.createErrorResponse(
+            SignInStrings.SignInCanceledMissingMfa,
+            StatusCode.CanceledMfa
+          );
         }
         return this.bypassChecksAndSignInWithRootKey(
           email,


### PR DESCRIPTION
Also renamed `HttpStatusCode` to `StatusCode` as there was already a precedent set for using proprietary code numbers