### PR TITLE
fix: mobile passcode keyboard type migration

### DIFF
--- a/dist/snjs.js
+++ b/dist/snjs.js
@@ -16917,7 +16917,7 @@ class _2020_01_15_Migration20200115 extends migration_Migration {
       rawStructure.nonwrapped[StorageKey.MobileBiometricsTiming] = biometricPrefs.timing;
     }
 
-    const passcodeKeyboardType = await this.services.deviceInterface.getJsonParsedRawStorageValue(LegacyKeys.MobilePasscodeKeyboardType);
+    const passcodeKeyboardType = await this.services.deviceInterface.getRawStorageValue(LegacyKeys.MobilePasscodeKeyboardType);
 
     if (passcodeKeyboardType) {
       rawStructure.nonwrapped[StorageKey.MobilePasscodeKeyboardType] = passcodeKeyboardType;

--- a/lib/migrations/2020-01-15.ts
+++ b/lib/migrations/2020-01-15.ts
@@ -325,7 +325,7 @@ export class Migration20200115 extends Migration {
       rawStructure.nonwrapped![StorageKey.BiometricsState] = biometricPrefs.enabled;
       rawStructure.nonwrapped![StorageKey.MobileBiometricsTiming] = biometricPrefs.timing;
     }
-    const passcodeKeyboardType = await this.services.deviceInterface.getJsonParsedRawStorageValue(
+    const passcodeKeyboardType = await this.services.deviceInterface.getRawStorageValue(
       LegacyKeys.MobilePasscodeKeyboardType
     );
     if (passcodeKeyboardType) {

--- a/test/migrations/2020-01-15-mobile.test.js
+++ b/test/migrations/2020-01-15-mobile.test.js
@@ -252,7 +252,7 @@ describe('2020-01-15 mobile migration', () => {
     const passcodeKeyboardType = 'numeric';
     await application.deviceInterface.setRawStorageValue(
       'passcodeKeyboardType',
-      JSON.stringify(passcodeKeyboardType)
+      passcodeKeyboardType
     );
     await application.deviceInterface.setRawStorageValue(
       'first_run',


### PR DESCRIPTION
Passcode keyboard type was not stringified so it has to be read directly.