### PR TITLE
fix: remove generic types from abstract class

### DIFF
--- a/dist/@types/device_interface.d.ts
+++ b/dist/@types/device_interface.d.ts
@@ -52,7 +52,7 @@ export declare abstract class DeviceInterface {
     abstract getNamespacedKeychainValue(identifier: ApplicationIdentifier): Promise<any>;
     abstract setNamespacedKeychainValue(value: any, identifier: ApplicationIdentifier): Promise<void>;
     abstract clearNamespacedKeychainValue(identifier: ApplicationIdentifier): Promise<void>;
-    abstract getRawKeychainValue<T = unknown>(): Promise<T | undefined | null>;
+    abstract getRawKeychainValue(): Promise<Record<string, any> | undefined | null>;
     abstract clearRawKeychainValue(): Promise<void>;
     abstract openUrl(url: string): void;
 }

--- a/lib/device_interface.ts
+++ b/lib/device_interface.ts
@@ -84,7 +84,7 @@ export abstract class DeviceInterface {
 
   abstract async clearNamespacedKeychainValue(identifier: ApplicationIdentifier) : Promise<void>;
 
-  abstract async getRawKeychainValue<T = unknown>() : Promise<T | undefined | null>;
+  abstract async getRawKeychainValue() : Promise<Record<string, any> | undefined | null>;
 
   abstract async clearRawKeychainValue() : Promise<void>;
 

--- a/lib/migrations/2020-01-15.ts
+++ b/lib/migrations/2020-01-15.ts
@@ -47,7 +47,7 @@ type LegacyMobileKeychainStructure = {
   ak: string
   version?: string
   jwt?: string
-};
+} | undefined | null;
 const LEGACY_SESSION_TOKEN_KEY = 'jwt';
 
 export class Migration20200115 extends Migration {
@@ -328,7 +328,7 @@ export class Migration20200115 extends Migration {
       [ValueModesKeys.Unwrapped]: {},
       [ValueModesKeys.Wrapped]: {},
     };
-    const keychainValue = await this.services.deviceInterface.getRawKeychainValue<LegacyMobileKeychainStructure>();
+    const keychainValue = await this.services.deviceInterface.getRawKeychainValue() as LegacyMobileKeychainStructure;
     const biometricPrefs = await this.services.deviceInterface.getJsonParsedRawStorageValue(
       LegacyKeys.MobileBiometricsPrefs
     );


### PR DESCRIPTION
Unfortunately, it's not possible to use generic methods when extending abstract classes in typescript so this has to be refactored.