### PR TITLE
feat: add running test suite orchestrated with Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,5 +15,5 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run lint
-      - run: npm run tsc
+      - run: npm run bundle
       - run: npm test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,7 @@ on:
     branches: [ 004 ]
 
 jobs:
-  publish-gpr:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -16,3 +16,4 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run tsc
+      - run: npm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run lint
-      - run: npm run tsc
+      - run: npm run bundle
       - run: npm test
 
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,11 @@
-name: Node.js Package
+name: Publish
 
 on:
   push:
     branches: [ 004 ]
 
 jobs:
-  publish-gpr:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -15,6 +15,20 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run lint
+      - run: npm run tsc
+      - run: npm test
+
+  publish:
+    needs: test
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
       - run: npm run bundle
       - run: npm publish
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM node:12.19.0-alpine
+
+ARG UID=1001
+ARG GID=1001
+
+RUN apk --no-cache --virtual build-dependencies add \
+    python \
+    make \
+    g++
+
+RUN addgroup -S snjs -g $GID && adduser -D -S snjs -G snjs -u $UID
+
+WORKDIR /var/www
+
+RUN chown -R $UID:$GID .
+
+USER snjs
+
+COPY --chown=$UID:$GID package.json package-lock.json /var/www/
+
+RUN npm ci
+
+USER root
+RUN apk del build-dependencies
+USER snjs
+
+COPY --chown=$UID:$GID . /var/www
+
+RUN npm run bundle
+
+EXPOSE 9001
+
+CMD [ "npm", "run", "start:test-server" ]

--- a/README.md
+++ b/README.md
@@ -126,14 +126,10 @@ app.streamItems(
 
 ## Tests
 
-Tests must be run in the browser due to WebCrypto dependency.
-
-1. `npm test`
-2. Open browser to `http://localhost:9001/test/test.html`.
-
-Tests depend on a [syncing-server](https://github.com/standardnotes/syncing-server) instance running locally on port 3000 and using the `test` environment (`rails s -e test`) (Use branch `develop` of the server repository for latest). This port can be [configured](https://github.com/standardnotes/snjs/blob/004/test/lib/factory.js#L247) as necessary.
-
-_Note:_ Many tests involve registering for a new account as part of the `beforeEach` block for that test suite. Each account registration call takes close to 1 second, as key generation with Argon2 is tuned to take close to 1 second. However, this will depend on machine performance. If a test fails due to timeout being exceeded, please increase the timeout for that test. Note that the browser tab which runs the tests must remain in the foreground while the tests are running due to browsers de-optimizing inactive tabs.
+Please make sure you have [Docker](https://www.docker.com) installed before running tests:
+```
+npm test
+```
 
 ## Notes
 - Almost all functions are asynchronous and return promises. [You can read about promises here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,6 @@ services:
   syncing-server-ruby:
     image: standardnotes/syncing-server:stable
     environment:
-      EXPOSED_PORT: 3000
       RAILS_ENV: test
       RAILS_LOG_TO_STDOUT: 1
       DB_PORT: 3306
@@ -35,8 +34,8 @@ services:
       DB_DATABASE: testdb
       DB_USERNAME: testuser
       DB_PASSWORD: testpassword
-    expose:
-      - 3000
+    ports:
+      - 3123:3000
     restart: unless-stopped
     networks:
       - snjs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+version: '3.8'
+services:
+  snjs:
+    build: .
+    restart: unless-stopped
+    networks:
+      snjs: {}
+    ports:
+      - 9001:9001
+    volumes:
+      - .:/var/www/
+
+  db:
+    image: mysql:5.6
+    environment:
+      MYSQL_DATABASE: testdb
+      MYSQL_USER: testuser
+      MYSQL_PASSWORD: testpassword
+      MYSQL_ROOT_PASSWORD: testpassword
+    expose:
+      - 3306
+    restart: unless-stopped
+    command: --default-authentication-plugin=mysql_native_password --character-set-server=utf8 --collation-server=utf8_general_ci
+    networks:
+      - snjs
+
+  syncing-server-ruby:
+    image: standardnotes/syncing-server:stable
+    environment:
+      EXPOSED_PORT: 3000
+      RAILS_ENV: test
+      RAILS_LOG_TO_STDOUT: 1
+      DB_PORT: 3306
+      DB_HOST: db
+      DB_DATABASE: testdb
+      DB_USERNAME: testuser
+      DB_PASSWORD: testpassword
+    expose:
+      - 3000
+    restart: unless-stopped
+    networks:
+      - snjs
+
+networks:
+  snjs:
+    name: snjs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "snjs",
-  "version": "2.0.3",
+  "name": "@standardnotes/snjs",
+  "version": "2.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2520,6 +2520,16 @@
       "resolved": "https://registry.npmjs.org/@standardnotes/sncrypto-common/-/sncrypto-common-1.2.9.tgz",
       "integrity": "sha512-xJ5IUGOZztjSgNP/6XL+Ut5+q9UgSTv6xMtKkcQC5aJxCOkJy9u6RamPLdF00WQgwibxx2tu0e43bKUjTgzMig=="
     },
+    "@standardnotes/sncrypto-web": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@standardnotes/sncrypto-web/-/sncrypto-web-1.2.9.tgz",
+      "integrity": "sha512-OJVsoLiKoFHkEnrRImZQ6fH5H0ptk67IrVrb97Y4WEDLVABqEkX/HgdjaQwnreXWc489fqtg3BVvfgIPS7GXnQ==",
+      "dev": true,
+      "requires": {
+        "@standardnotes/sncrypto-common": "^1.2.7",
+        "libsodium-wrappers": "^0.7.8"
+      }
+    },
     "@types/chai": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
@@ -2578,6 +2588,16 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.31.tgz",
       "integrity": "sha512-T+wnJno8uh27G9c+1T+a1/WYCHzLeDqtsGJkoEdSp2X8RTh3oOCZQcUnjAx90CS8cmmADX51O0FI/tu9s0yssg==",
       "dev": true
+    },
+    "@types/yauzl": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
+      "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "3.10.1",
@@ -2925,6 +2945,12 @@
       "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
       "dev": true
     },
+    "agent-base": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
+      "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
+      "dev": true
+    },
     "ajv": {
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
@@ -3021,6 +3047,32 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
           "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+          "dev": true
+        }
+      }
+    },
+    "args": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/args/-/args-5.0.1.tgz",
+      "integrity": "sha512-1kqmFCFsPffavQFGt8OxJdIcETti99kySRUPMpOhaGjL6mRJn8HFU1OxKY5bMqfZKUwTQc1mZkAjmGYaVOHFtQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "5.0.0",
+        "chalk": "2.4.2",
+        "leven": "2.1.0",
+        "mri": "1.1.4"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+          "dev": true
+        },
+        "leven": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+          "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
           "dev": true
         }
       }
@@ -3397,6 +3449,46 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "bl": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -3553,6 +3645,12 @@
         "ieee754": "^1.1.4",
         "isarray": "^1.0.0"
       }
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -4884,6 +4982,44 @@
         }
       }
     },
+    "extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "requires": {
+        "@types/yauzl": "^2.9.1",
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -4915,6 +5051,15 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "dev": true,
+      "requires": {
+        "pend": "~1.2.0"
+      }
     },
     "figgy-pudding": {
       "version": "3.5.1",
@@ -5127,6 +5272,12 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
       }
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
     },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
@@ -5984,6 +6135,33 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
+    "https-proxy-agent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+      "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+      "dev": true,
+      "requires": {
+        "agent-base": "5",
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -6509,6 +6687,21 @@
         "type-check": "~0.3.2"
       }
     },
+    "libsodium": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.8.tgz",
+      "integrity": "sha512-/Qc+APf0jbeWSaeEruH0L1/tbbT+sbf884ZL0/zV/0JXaDPBzYkKbyb/wmxMHgAHzm3t6gqe7bOOXAVwfqVikQ==",
+      "dev": true
+    },
+    "libsodium-wrappers": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.8.tgz",
+      "integrity": "sha512-PDhPWXBqd/SaqAFUBgH2Ux7b3VEEJgyD6BQB+VdNFJb9PbExGr/T/myc/MBoSvl8qLzfm0W0IVByOQS5L1MrCg==",
+      "dev": true,
+      "requires": {
+        "libsodium": "0.7.8"
+      }
+    },
     "load-json-file": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -6783,6 +6976,12 @@
         "through2": "^2.0.0"
       }
     },
+    "mitt": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-2.1.0.tgz",
+      "integrity": "sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg==",
+      "dev": true
+    },
     "mixin-deep": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
@@ -6812,6 +7011,12 @@
       "requires": {
         "minimist": "0.0.8"
       }
+    },
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true
     },
     "mocha": {
       "version": "7.1.0",
@@ -6999,6 +7204,25 @@
         }
       }
     },
+    "mocha-headless-chrome": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mocha-headless-chrome/-/mocha-headless-chrome-3.1.0.tgz",
+      "integrity": "sha512-qHz9D+Hzd8tDaNvPooUnvilWvAy1l+cJCBsV7dsme4wDKpvIaKRVGjU8RoirTfWQCkNOpjbweDpuNgo8wuOSHQ==",
+      "dev": true,
+      "requires": {
+        "args": "^5.0.1",
+        "mkdirp": "^1.0.4",
+        "puppeteer": "^4.0.0"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        }
+      }
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -7012,6 +7236,12 @@
         "rimraf": "^2.5.4",
         "run-queue": "^1.0.3"
       }
+    },
+    "mri": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+      "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==",
+      "dev": true
     },
     "ms": {
       "version": "2.0.0",
@@ -7527,6 +7757,12 @@
         "sha.js": "^2.4.8"
       }
     },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
@@ -7604,6 +7840,12 @@
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
+    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -7662,6 +7904,57 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "dev": true
+    },
+    "puppeteer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-4.0.1.tgz",
+      "integrity": "sha512-LIiSWTRqpTnnm3R2yAoMBx1inSeKwVZy66RFSkgSTDINzheJZPd5z5mMbPM0FkvwWAZ27a+69j5nZf+Fpyhn3Q==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "extract-zip": "^2.0.0",
+        "https-proxy-agent": "^4.0.0",
+        "mime": "^2.0.3",
+        "mitt": "^2.0.1",
+        "progress": "^2.0.1",
+        "proxy-from-env": "^1.0.0",
+        "rimraf": "^3.0.2",
+        "tar-fs": "^2.0.0",
+        "unbzip2-stream": "^1.3.3",
+        "ws": "^7.2.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "mime": {
+          "version": "2.4.6",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
     },
     "querystring": {
       "version": "0.2.0",
@@ -8641,6 +8934,44 @@
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
       "dev": true
     },
+    "tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "dev": true,
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "tar-stream": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
+      "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "terser": {
       "version": "4.6.6",
       "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.6.tgz",
@@ -8948,6 +9279,28 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.5.tgz",
       "integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==",
       "dev": true
+    },
+    "unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        }
+      }
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -9384,6 +9737,12 @@
         "mkdirp": "^0.5.1"
       }
     },
+    "ws": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
+      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==",
+      "dev": true
+    },
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -9461,6 +9820,16 @@
         "flat": "^4.1.0",
         "lodash": "^4.17.15",
         "yargs": "^13.3.0"
+      }
+    },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "docs": "jsdoc -c jsdoc.json",
     "tsc": "tsc --project lib/tsconfig.json && tscpaths -p lib/tsconfig.json -s lib -o dist/@types",
     "start:test-server": "node test-server.js",
-    "test": "./test.sh",
+    "test": "bash test.sh",
     "lint": "eslint . --ext .ts"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@standardnotes/snjs",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "engines": {
     "node": ">=12.19.0 <14.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -17,12 +17,14 @@
     "bundle": "webpack --config webpack.prod.js && npm run tsc",
     "docs": "jsdoc -c jsdoc.json",
     "tsc": "tsc --project lib/tsconfig.json && tscpaths -p lib/tsconfig.json -s lib -o dist/@types",
-    "test": "node test-server.js",
+    "start:test-server": "node test-server.js",
+    "test": "./test.sh",
     "lint": "eslint . --ext .ts"
   },
   "devDependencies": {
     "@babel/core": "^7.10.4",
     "@babel/preset-env": "^7.10.4",
+    "@standardnotes/sncrypto-web": "^1.2.9",
     "@types/chai": "^4.2.11",
     "@types/lodash": "^4.14.149",
     "@types/mocha": "^7.0.2",
@@ -46,6 +48,7 @@
     "exports-loader": "^0.7.0",
     "lodash": "^4.17.19",
     "mocha": "^7.1.0",
+    "mocha-headless-chrome": "^3.1.0",
     "pre-push": "^0.1.1",
     "regenerator-runtime": "^0.13.5",
     "script-loader": "^0.7.2",

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-# !/bin/bash
+# !/bin/sh
 
 echo "Killing all containers"
 docker-compose kill

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,32 @@
+# !/bin/bash
+
+echo "Killing all containers"
+docker-compose kill
+echo "Removing all containers"
+docker-compose rm -f
+echo "Starting all containers"
+docker-compose up -d
+attempt=0
+while [ $attempt -le 59 ]; do
+    attempt=$(( $attempt + 1 ))
+    echo "Waiting for Syncing Server to be up (attempt: $attempt)..."
+    result=$(docker-compose logs syncing-server-ruby)
+    if grep -q 'Starting Server' <<< $result ; then
+        sleep 2 # for warmup
+        echo "Syncing Server is up!"
+        break
+    fi
+    sleep 2
+done
+echo "Starting Test Suite"
+npx mocha-headless-chrome -f http://localhost:9001/test/test.html -t 600000
+test_result=$?
+echo "Killing all containers"
+docker-compose kill
+
+if [ $test_result == 0 ]
+then
+  exit 0
+else
+  exit 1
+fi

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-# !/bin/sh
+# !/bin/bash
 
 echo "Killing all containers"
 docker-compose kill

--- a/test.sh
+++ b/test.sh
@@ -1,27 +1,27 @@
 # !/bin/bash
 
-echo "Killing all containers"
+echo "# Killing all containers"
 docker-compose kill
-echo "Removing all containers"
+echo "# Removing all containers"
 docker-compose rm -f
-echo "Starting all containers"
+echo "# Starting all containers"
 docker-compose up -d
 attempt=0
 while [ $attempt -le 59 ]; do
     attempt=$(( $attempt + 1 ))
-    echo "Waiting for Syncing Server to be up (attempt: $attempt)..."
+    echo "# Waiting for Syncing Server to be up (attempt: $attempt)..."
     result=$(docker-compose logs syncing-server-ruby)
     if grep -q 'Starting Server' <<< $result ; then
         sleep 2 # for warmup
-        echo "Syncing Server is up!"
+        echo "# Syncing Server is up!"
         break
     fi
     sleep 2
 done
-echo "Starting Test Suite"
+echo "# Starting Test Suite"
 npx mocha-headless-chrome -f http://localhost:9001/test/test.html -t 600000
 test_result=$?
-echo "Killing all containers"
+echo "# Killing all containers"
 docker-compose kill
 
 if [ $test_result == 0 ]

--- a/test/lib/factory.js
+++ b/test/lib/factory.js
@@ -28,7 +28,7 @@ export function createApplication(identifier, environment, platform) {
     identifier,
     undefined,
     undefined,
-    'http://localhost:3000'
+    'http://localhost:3123'
   );
 }
 

--- a/test/test.html
+++ b/test/test.html
@@ -7,11 +7,11 @@
         <script src="./vendor/chai-as-promised-built.js"></script>
         <script src="../node_modules/regenerator-runtime/runtime.js"></script>
         <script src="../node_modules/mocha/mocha.js"></script>
-        <script src="../node_modules/sncrypto/dist/sncrypto-web.js"></script>
+        <script src="../node_modules/@standardnotes/sncrypto-web/dist/sncrypto-web.js"></script>
         <script src="../node_modules/sinon/pkg/sinon.js"></script>
         <script src="../dist/snjs.js"></script>
         <script>
-          window._default_sync_server = 'http://localhost:3000';
+          window._default_sync_server = 'http://syncing-server-ruby:3000';
           Object.assign(window, SNCrypto);
           Object.assign(window, SNLibrary);
           SNLog.onLog = (message) => {

--- a/test/test.html
+++ b/test/test.html
@@ -11,7 +11,7 @@
         <script src="../node_modules/sinon/pkg/sinon.js"></script>
         <script src="../dist/snjs.js"></script>
         <script>
-          window._default_sync_server = 'http://syncing-server-ruby:3000';
+          window._default_sync_server = 'http://syncing-server-ruby:3123';
           Object.assign(window, SNCrypto);
           Object.assign(window, SNLibrary);
           SNLog.onLog = (message) => {


### PR DESCRIPTION
- Added running a Docker orchestrated test suite
- Added the test suite to run on github workflows

You can run the test suite locally without having to open the browser by typing `npm test`.

You can also see the tests that have been run on this PR

*NOTE*: Please keep in mind that the tests on this PR should be failing as this is the current state of the tests. This PR only introduces the setup for running tests and should be merged even though a failing check status. The tests that are failing should be fixed in a separate issue/PR.