### PR TITLE
fix: safe use of postMessage

### DIFF
--- a/lib/services/component_manager.ts
+++ b/lib/services/component_manager.ts
@@ -585,7 +585,7 @@ export class SNComponentManager extends PureService {
       origin = window.location.href + origin;
     }
     /* Mobile messaging requires json */
-    componentState.window!.postMessage(
+    componentState.window?.postMessage(
       this.isMobile ? JSON.stringify(message) : message,
       origin!
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@standardnotes/snjs",
-  "version": "2.0.13",
+  "version": "2.0.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@standardnotes/snjs",
-  "version": "2.0.13",
+  "version": "2.0.17",
   "engines": {
     "node": ">=14.0.0 <15.0.0"
   },


### PR DESCRIPTION
There are some random cases when `component.window` is undefined and accessing `postMessage` fails (even if there is a check up there). This can happen when app gets locked suddently or when the users leaves the screen before an event is sent from the editor.