### PR TITLE
feat: reroute sessions to syncing-server-js

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     depends_on:
       - syncing-server-proxy
       - syncing-server-ruby
-    image: standardnotes/syncing-server-js:stable
+    image: standardnotes/syncing-server-js:latest
     entrypoint: ["/tools/wait-for.sh", "syncing-server-ruby", "3000", "./docker/entrypoint.sh", "start-web"]
     environment:
       LOG_LEVEL: info

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     depends_on:
       - syncing-server-proxy
       - syncing-server-ruby
-    image: standardnotes/syncing-server-js:latest
+    image: standardnotes/syncing-server-js:stable
     entrypoint: ["/tools/wait-for.sh", "syncing-server-ruby", "3000", "./docker/entrypoint.sh", "start-web"]
     environment:
       LOG_LEVEL: info

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@standardnotes/snjs",
-  "version": "2.0.20",
+  "version": "2.0.21",
   "engines": {
     "node": ">=14.0.0 <15.0.0"
   },

--- a/test/proxy.conf.template
+++ b/test/proxy.conf.template
@@ -19,11 +19,7 @@ server {
         proxy_pass         ${NGINX_REROUTE_HOST};
     }
 
-    location ~ ^/session/all {
-        proxy_pass         ${NGINX_REROUTE_HOST};
-    }
-
-    location ~ ^/session$ {
+    location ~ ^/session.* {
         proxy_pass         ${NGINX_REROUTE_HOST};
     }
 


### PR DESCRIPTION
This reroutes all the session management traffic (in the js test suite) to syncing-server-js.

The following paths/resources are rerouted:
```
# EXCERPT from Syncing Server Ruby
  # sessions management
  post "session/refresh" => "api/sessions#refresh"
  get "sessions" => "api/sessions#index"
  delete "session" => "api/sessions#delete"
  delete "session/all" => "api/sessions#delete_all"
```