### PR TITLE
feature: use challenges for privileges authentication

### DIFF
--- a/lib/application.ts
+++ b/lib/application.ts
@@ -1649,8 +1649,7 @@ export class SNApplication {
 
   private createPrivilegesService() {
     this.privilegesService = new SNPrivilegesService(
-      this.itemManager,
-      this.syncService,
+      this.challengeService,
       this.singletonManager,
       this.protocolService,
       this.storageService,

--- a/lib/challenges.ts
+++ b/lib/challenges.ts
@@ -118,7 +118,7 @@ export class ChallengePrompt {
     public readonly placeholder?: string,
     public readonly secureTextEntry = true,
     public readonly keyboardType?: ChallengeKeyboardType,
-    public readonly formValues?: ChallengeFormValue[]
+    public readonly formValues?: ChallengeFormValue[],
   ) {
     Object.freeze(this);
   }
@@ -147,7 +147,7 @@ export class ChallengePrompt {
 export class ChallengeValue {
   constructor(
     public readonly prompt: ChallengePrompt,
-    public readonly value: string | boolean | ChallengeFormValue,
+    public readonly value: string | boolean | number,
   ) {
     Object.freeze(this);
   }

--- a/lib/challenges.ts
+++ b/lib/challenges.ts
@@ -1,4 +1,3 @@
-import { Migration } from '@Lib/migrations/migration';
 import { ChallengeModalTitle, ChallengeStrings, PromptTitles } from './services/api/messages';
 import { SNRootKey } from '@Protocol/root_key';
 
@@ -12,6 +11,7 @@ export enum ChallengeValidation {
   LocalPasscode = 1,
   AccountPassword = 2,
   Biometric = 3,
+  Form = 4,
 }
 
 /** The source of the challenge */
@@ -20,13 +20,19 @@ export enum ChallengeReason {
   ResaveRootKey = 2,
   ProtocolUpgrade = 3,
   Migration = 4,
-  Custom = 5
+  AuthenticatePrivilege = 6,
+  Custom = 5,
 }
 
 /** For mobile */
 export enum ChallengeKeyboardType {
   Alphanumeric = 'default',
   Numeric = 'numeric'
+}
+
+export type ChallengeFormValue = {
+  value: number,
+  label: string
 }
 
 /**
@@ -111,7 +117,8 @@ export class ChallengePrompt {
     public readonly _title?: string,
     public readonly placeholder?: string,
     public readonly secureTextEntry = true,
-    public readonly keyboardType?: ChallengeKeyboardType
+    public readonly keyboardType?: ChallengeKeyboardType,
+    public readonly formValues?: ChallengeFormValue[]
   ) {
     Object.freeze(this);
   }
@@ -140,7 +147,7 @@ export class ChallengePrompt {
 export class ChallengeValue {
   constructor(
     public readonly prompt: ChallengePrompt,
-    public readonly value: string | boolean,
+    public readonly value: string | boolean | ChallengeFormValue,
   ) {
     Object.freeze(this);
   }

--- a/lib/models/app/privileges.ts
+++ b/lib/models/app/privileges.ts
@@ -14,7 +14,7 @@ export enum ProtectedAction {
 
 export enum PrivilegeCredential {
   AccountPassword = 'CredentialAccountPassword',
-  LocalPasscode = 'CredentialLocalPasscode'
+  LocalAuthentication = 'CredentialLocalPasscode'
 }
 
 type PrivilegeMap = Partial<Record<ProtectedAction, PrivilegeCredential[]>>

--- a/lib/services/api/messages.ts
+++ b/lib/services/api/messages.ts
@@ -139,6 +139,7 @@ export const PromptTitles = {
   AccountPassword: 'Account Password',
   LocalPasscode: 'Application Passcode',
   Biometrics: 'Biometrics',
+  SessionLength: 'Remember for'
 }
 
 export const ErrorAlertStrings = {

--- a/lib/services/challenge/challenge_service.ts
+++ b/lib/services/challenge/challenge_service.ts
@@ -1,5 +1,5 @@
 import { SNRootKey } from './../../protocol/root_key';
-import { ChallengePrompt } from './../../challenges';
+import { ChallengeFormValue, ChallengePrompt } from './../../challenges';
 import { SNProtocolService } from "../protocol_service";
 import { SNStorageService } from "../storage_service";
 import { PureService } from "@Lib/services/pure_service";
@@ -80,6 +80,8 @@ export class ChallengeService extends PureService {
         );
       case ChallengeValidation.Biometric:
         return Promise.resolve({ valid: value.value === true });
+      case ChallengeValidation.Form:
+        return Promise.resolve({ valid: Number.isInteger((value.value as ChallengeFormValue).value) });
       default:
         throw Error(`Unhandled validation mode ${value.prompt.validation}`)
     }

--- a/lib/services/challenge/challenge_service.ts
+++ b/lib/services/challenge/challenge_service.ts
@@ -81,7 +81,7 @@ export class ChallengeService extends PureService {
       case ChallengeValidation.Biometric:
         return Promise.resolve({ valid: value.value === true });
       case ChallengeValidation.Form:
-        return Promise.resolve({ valid: Number.isInteger((value.value as ChallengeFormValue).value) });
+        return Promise.resolve({ valid: Number.isInteger(value.value) });
       default:
         throw Error(`Unhandled validation mode ${value.prompt.validation}`)
     }

--- a/lib/services/privileges_service.ts
+++ b/lib/services/privileges_service.ts
@@ -130,8 +130,7 @@ export class SNPrivilegesService extends PureService {
           netCredentials.push(credential);
         }
       } else if (credential === PrivilegeCredential.LocalAuthentication) {
-        const hasPasscode = await this.protocolService!.hasRootKeyWrapper();
-        if (hasPasscode) {
+        if (await this.hasPasscode()) {
           netCredentials.push(credential);
         } else if (await this.hasBiometrics()) {
           netCredentials.push(credential);
@@ -329,11 +328,11 @@ export class SNPrivilegesService extends PureService {
     ];
   }
 
-  hasPasscode() {
+  private hasPasscode() {
     return this.protocolService!.hasRootKeyWrapper();
   }
 
-  hasBiometrics() {
+  private hasBiometrics() {
     return this.challengeService?.hasBiometricsEnabled();
   }
 }

--- a/test/privileges.test.js
+++ b/test/privileges.test.js
@@ -40,7 +40,7 @@ describe('privileges', () => {
     await this.application.itemManager.changeItem(privileges.uuid, (mutator) => {
       mutator.addCredentialForAction(
         ProtectedAction.ViewProtectedNotes,
-        PrivilegeCredential.LocalPasscode
+        PrivilegeCredential.LocalAuthentication
       );
     });
     await this.application.setPasscode('foobar');


### PR DESCRIPTION
By reusing challenges we can easily simplify authentication for biometrics and get rid of a ot of code. This deprecates the old code so it still can be used for some time.

There is a new Challenge prompt with type Form that makes it possible to set session length. Clients does not have to set it manually anomie as well.