### PR TITLE
client-facing sessions management

### DIFF
--- a/lib/application.ts
+++ b/lib/application.ts
@@ -65,6 +65,8 @@ import { ProtocolVersion, compareVersions } from './protocol/versions';
 import { KeyParamsOrigination } from './protocol/key_params';
 import { SNLog } from './log';
 import { SNPreferencesService } from './services/preferences_service';
+import { HttpResponse } from './services/api/responses';
+import { RemoteSession } from './services/api/session';
 
 /** How often to automatically sync, in milliseconds */
 const DEFAULT_AUTO_SYNC_INTERVAL = 30000;
@@ -479,6 +481,14 @@ export class SNApplication {
 
   public getSyncStatus() {
     return this.syncService!.getStatus()!;
+  }
+
+  public getSessions(): Promise<RemoteSession[] | HttpResponse> {
+    return this.sessionManager.getSessionsList();
+  }
+
+  public revokeSession(sessionId: UuidString): Promise<HttpResponse> {
+    return this.sessionManager.revokeSession(sessionId);
   }
 
   /**

--- a/lib/application.ts
+++ b/lib/application.ts
@@ -19,7 +19,7 @@ import { ChallengeObserver } from './services/challenge/challenge_service';
 import { PureService } from '@Lib/services/pure_service';
 import { SNPureCrypto } from '@standardnotes/sncrypto-common';
 import { Environment, Platform } from './platforms';
-import { isString, removeFromArray, sleep } from '@Lib/utils';
+import { isNullOrUndefined, isString, removeFromArray, sleep } from '@Lib/utils';
 import { ContentType } from '@Models/content_types';
 import { CopyPayload, CreateMaxPayloadFromAnyObject, PayloadContent } from '@Payloads/generator';
 import { PayloadSource } from '@Payloads/sources';
@@ -489,6 +489,14 @@ export class SNApplication {
 
   public revokeSession(sessionId: UuidString): Promise<HttpResponse> {
     return this.sessionManager.revokeSession(sessionId);
+  }
+
+  public async userCanManageSessions(): Promise<boolean> {
+    const userVersion = await this.getUserVersion();
+    if (isNullOrUndefined(userVersion)) {
+      return false;
+    }
+    return compareVersions(userVersion, ProtocolVersion.V004) >= 0;
   }
 
   /**

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -9,6 +9,7 @@ export { SNApplicationGroup } from './application_group';
 export { DeinitSource } from './types';
 export { KeyParamsOrigination } from './protocol/key_params';
 export { KeyRecoveryStrings, SessionStrings } from './services/api/messages';
+export type { RemoteSession } from './services/api/session';
 
 export { SNApplication } from '@Lib/application';
 export { SNProtocolService, KeyMode } from '@Services/protocol_service';

--- a/lib/services/api/api_service.ts
+++ b/lib/services/api/api_service.ts
@@ -35,6 +35,7 @@ const REQUEST_PATH_SYNC = '/items/sync';
 const REQUEST_PATH_LOGOUT = '/auth/sign_out';
 const REQUEST_PATH_SESSION_REFRESH = '/session/refresh';
 const REQUEST_PATH_ALL_SESSIONS = '/sessions';
+const REQUEST_PATH_SESSION = '/session';
 const REQUEST_PATH_ITEM_REVISIONS = '/items/:item_id/revisions';
 const REQUEST_PATH_ITEM_REVISION = '/items/:item_id/revisions/:id';
 
@@ -92,7 +93,7 @@ export class SNApiService extends PureService {
     await this.storageService.setValue(StorageKey.ServerHost, host);
   }
 
-  public async getHost() {
+  public getHost() {
     return this.host;
   }
 
@@ -391,6 +392,34 @@ export class SNApiService extends PureService {
     });
 
     return response as SessionListResponse;
+  }
+
+  async deleteSession(sessionId: UuidString): Promise<RevisionListResponse | HttpResponse> {
+    const preprocessingError = this.preprocessingError();
+    if (preprocessingError) {
+      return preprocessingError;
+    }
+    const url = await this.path(REQUEST_PATH_SESSION);
+    try {
+      return this.httpService.deleteAbsolute(
+        url,
+        { uuid: sessionId },
+        this.session!.authorizationValue
+      );
+    } catch (error) {
+      const errorResponse = error as HttpResponse;
+      this.preprocessAuthenticatedErrorResponse(errorResponse);
+      if (isErrorResponseExpiredToken(errorResponse)) {
+        return this.refreshSessionThenRetryRequest({
+          verb: HttpVerb.Get,
+          url
+        });
+      }
+      return this.errorResponseWithFallbackMessage(
+        errorResponse,
+        messages.API_MESSAGE_GENERIC_SYNC_FAIL
+      );
+    }
   }
 
   async getItemRevisions(

--- a/lib/services/api/http_service.ts
+++ b/lib/services/api/http_service.ts
@@ -5,7 +5,8 @@ import { HttpResponse, StatusCode } from './responses';
 export enum HttpVerb {
   Get = 'get',
   Post = 'post',
-  Patch = 'patch'
+  Patch = 'patch',
+  Delete = 'delete',
 }
 
 const REQUEST_READY_STATE_COMPLETED = 4;
@@ -48,6 +49,14 @@ export class SNHttpService extends PureService {
     return this.runHttp({ url, params, verb: HttpVerb.Patch, authentication });
   }
 
+  public async deleteAbsolute(
+    url: string,
+    params?: HttpParams,
+    authentication?: string
+  ): Promise<HttpResponse> {
+    return this.runHttp({ url, params, verb: HttpVerb.Delete, authentication });
+  }
+
   public async runHttp(httpRequest: HttpRequest): Promise<HttpResponse> {
     const request = this.createXmlRequest(httpRequest);
     return this.runRequest(request, httpRequest.verb, httpRequest.params);
@@ -79,7 +88,7 @@ export class SNHttpService extends PureService {
       request.onreadystatechange = () => {
         this.stateChangeHandlerForRequest(request, resolve, reject);
       };
-      if (verb === HttpVerb.Post || verb === HttpVerb.Patch) {
+      if (verb === HttpVerb.Post || verb === HttpVerb.Patch || verb === HttpVerb.Delete) {
         request.send(JSON.stringify(params));
       } else {
         request.send();
@@ -100,9 +109,11 @@ export class SNHttpService extends PureService {
       status: httpStatus
     }
     try {
-      const body = JSON.parse(request.responseText);
-      response.object = body;
-      Object.assign(response, body);
+      if (httpStatus !== StatusCode.HttpStatusNoContent) {
+        const body = JSON.parse(request.responseText);
+        response.object = body;
+        Object.assign(response, body);
+      }
     } catch (error) {
       console.error(error)
     }

--- a/lib/services/api/responses.ts
+++ b/lib/services/api/responses.ts
@@ -5,6 +5,7 @@ import { ProtocolVersion } from './../../protocol/versions';
 
 export enum StatusCode {
   HttpStatusMinSuccess = 200,
+  HttpStatusNoContent = 204,
   HttpStatusMaxSuccess = 299,
   /** The session's access token is expired, but the refresh token is valid */
   HttpStatusExpiredAccessToken = 498,

--- a/lib/services/api/session.ts
+++ b/lib/services/api/session.ts
@@ -1,4 +1,5 @@
 import { SessionRenewalResponse } from './responses';
+import { UuidString } from '@Lib/types';
 
 type RawJwtPayload = {
   jwt?: string
@@ -11,13 +12,20 @@ type RawSessionPayload = {
 }
 type RawStorageValue = RawJwtPayload | RawSessionPayload
 
+export type RemoteSession = {
+  uuid: UuidString
+  updated_at: Date
+  device_info: string
+  current: boolean
+}
+
 export abstract class Session {
   public abstract canExpire(): boolean;
 
   /** Return the token that should be included in the header of authorized network requests */
   public abstract get authorizationValue(): string;
 
-  static FromRawStorageValue(raw: RawStorageValue) {
+  static FromRawStorageValue(raw: RawStorageValue): JwtSession | TokenSession {
     if ((raw as RawJwtPayload).jwt) {
       return new JwtSession(
         (raw as RawJwtPayload).jwt!
@@ -43,11 +51,11 @@ export class JwtSession extends Session {
     this.jwt = jwt;
   }
 
-  public get authorizationValue() {
+  public get authorizationValue(): string {
     return this.jwt;
   }
 
-  public canExpire() {
+  public canExpire(): false {
     return false;
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@standardnotes/snjs",
-  "version": "2.0.25",
+  "version": "2.0.26",
   "engines": {
     "node": ">=14.0.0 <15.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@standardnotes/snjs",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "engines": {
     "node": ">=14.0.0 <15.0.0"
   },

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -436,6 +436,22 @@ describe('server session', function () {
     expect(response2.object.length).to.equal(1);
   });
 
+  it('revoking a session should prevent further syncing', async function () {
+    /** Create new session aside from existing one */
+    const app2 = await Factory.createAndInitializeApplication('app2');
+    app2.prepareForLaunch({
+      receiveChallenge() {}
+    });
+    await app2.signIn(this.email, this.password);
+
+    const sessions = await this.application.getSessions();
+    const app2session = sessions.find(session => !session.current);
+    await this.application.revokeSession(app2session.uuid);
+
+    const note = await Factory.createSyncedNote(app2);
+    expect(this.application.findItem(note.uuid)).to.not.be.ok
+  });
+
   it('signing out with invalid session token should still delete local data', async function () {
     const invalidSession = this.application.apiService.getSession();
     invalidSession.accessToken = undefined;


### PR DESCRIPTION
Adds `SNApplication.getSessions()` and `SNApplication.revokeSession(uuid)`, filling in the missing functionality in apiService and sessionManager (mostly DELETE requests)