### PR TITLE
feat: environmentFromString function

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -134,7 +134,8 @@ export {
   Platform,
   isEnvironmentWebOrDesktop,
   isEnvironmentMobile,
-  platformFromString
+  platformFromString,
+  environmentFromString
 } from '@Lib/platforms';
 export {
   SyncEvent

--- a/lib/platforms.ts
+++ b/lib/platforms.ts
@@ -16,7 +16,7 @@ export enum Platform {
 }
 
 export function platformFromString(string: string) {
-  const map: Record<string, number> = {
+  const map: Record<string, Platform> = {
     'mac-web': Platform.MacWeb,
     'mac-desktop': Platform.MacDesktop,
     'linux-web': Platform.LinuxWeb,
@@ -44,7 +44,7 @@ export function platformToString(platform: Platform) {
 }
 
 export function environmentFromString(string: string) {
-  const map: Record<string, number> = {
+  const map: Record<string, Environment> = {
     'web': Environment.Web,
     'desktop': Environment.Desktop,
     'mobile': Environment.Mobile,

--- a/lib/platforms.ts
+++ b/lib/platforms.ts
@@ -43,6 +43,15 @@ export function platformToString(platform: Platform) {
   return map[platform];
 }
 
+export function environmentFromString(string: string) {
+  const map = {
+    'web': Environment.Web,
+    'desktop': Environment.Desktop,
+    'mobile': Environment.Mobile,
+  };
+  return (map as any)[string];
+}
+
 export function environmentToString(environment: Environment) {
   const map = {
     [Environment.Web]: 'web',

--- a/lib/platforms.ts
+++ b/lib/platforms.ts
@@ -16,7 +16,7 @@ export enum Platform {
 }
 
 export function platformFromString(string: string) {
-  const map = {
+  const map: Record<string, number> = {
     'mac-web': Platform.MacWeb,
     'mac-desktop': Platform.MacDesktop,
     'linux-web': Platform.LinuxWeb,
@@ -26,7 +26,7 @@ export function platformFromString(string: string) {
     'ios': Platform.Ios,
     'android': Platform.Android,
   };
-  return (map as any)[string];
+  return map[string];
 }
 
 export function platformToString(platform: Platform) {
@@ -44,12 +44,12 @@ export function platformToString(platform: Platform) {
 }
 
 export function environmentFromString(string: string) {
-  const map = {
+  const map: Record<string, number> = {
     'web': Environment.Web,
     'desktop': Environment.Desktop,
     'mobile': Environment.Mobile,
   };
-  return (map as any)[string];
+  return map[string];
 }
 
 export function environmentToString(environment: Environment) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@standardnotes/snjs",
-  "version": "2.0.27",
+  "version": "2.0.28",
   "engines": {
     "node": ">=14.0.0 <15.0.0"
   },


### PR DESCRIPTION
- adds a new function `environmentFromString`
- fixes type `(map as any)` on `platformFromString`

At the moment, `environmentFromString` will be used [here](https://github.com/johnny243/sn-components-api/blob/68b9dd1e5ea89ae99bb022a6f828da3883a6a87b/test/manager.test.ts#L140).

Also, `environmentFromString` is added to complement `environmentToString`.