### PR TITLE
chore: add support for node 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@standardnotes/snjs",
-  "version": "2.0.31",
+  "version": "2.0.32",
   "engines": {
-    "node": ">=14.0.0 <15.0.0"
+    "node": ">=14.0.0 <16.0.0"
   },
   "main": "dist/snjs.js",
   "types": "dist/@types",


### PR DESCRIPTION
As the minimum node version supported natively in arm64 Macs is 15, it would be good if we could add support for it.