### PR TITLE
chore: update README.md with correct link to encryption specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An application must be supplied a custom subclass of [DeviceInterface](lib/devic
 
 The application interacts with a variety of services and managers to facilitate complete client functionality. While the distinction is not fully technical, a service can be thought of as a class that allows consumers to perform actions on demand, while a manager is responsible for managing and reacting to application state (but also expose on-demand functions). All managers and services live in `lib/services`.
 
-On Web platforms SNJS interacts with [`sncrypto`](https://github.com/standardnotes/sncrypto/tree/004) to perform operations as mentioned in the [specification](https://github.com/standardnotes/snjs/blob/master/specification.md) document. This includes operations like key generation and data encryption.
+On Web platforms SNJS interacts with [`sncrypto`](https://github.com/standardnotes/sncrypto/tree/004) to perform operations as mentioned in the [specification](./packages/snjs/specification.md) document. This includes operations like key generation and data encryption.
 
 SNJS also interacts with a Standard Notes [syncing-server](https://github.com/standardnotes/syncing-server), which is dumb data and sync store that deals with encrypted data, and never learns of client secrets or sensitive information.
 


### PR DESCRIPTION
The specification link is currently broken. I updated the link with a relative link to the correct file. A relative link is better than an absolute link since it works across branches.