### PR TITLE
fix: enforce 2 spaces indentation

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@standardnotes/config",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "engines": {
     "node": ">=14.0.0 <16.0.0"
   },

--- a/packages/config/src/.eslintrc
+++ b/packages/config/src/.eslintrc
@@ -18,6 +18,7 @@
     "@typescript-eslint/no-floating-promises": ["error"],
     "semi": ["error", "never"],
     "quotes": ["error", "single"],
-    "object-curly-spacing": ["error", "always"]
+    "object-curly-spacing": ["error", "always"],
+    "indent": ["error", 2]
   }
 }

--- a/packages/domain-events/package.json
+++ b/packages/domain-events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@standardnotes/domain-events",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "engines": {
     "node": ">=14.0.0 <16.0.0"
   },
@@ -30,7 +30,7 @@
     "winston": "^3.3.3"
   },
   "devDependencies": {
-    "@standardnotes/config": "^1.0.1",
+    "@standardnotes/config": "^1.1.1",
     "@types/ioredis": "^4.17.10",
     "@types/jest": "^26.0.15",
     "jest": "^26.6.3",

--- a/packages/domain-events/src/Infra/SQS/SQSDomainEventSubscriberFactory.ts
+++ b/packages/domain-events/src/Infra/SQS/SQSDomainEventSubscriberFactory.ts
@@ -15,13 +15,13 @@ export class SQSDomainEventSubscriberFactory implements DomainEventSubscriberFac
 
   create (): DomainEventSubscriberInterface {
     const sqsConsumer = Consumer.create({
-        attributeNames: ['All'],
-        messageAttributeNames: ['compression', 'event'],
-        queueUrl: this.queueUrl,
-        sqs: this.sqs,
-        handleMessage:
-          /* istanbul ignore next */
-          async (message: SQSMessage) => await this.domainEventMessageHandler.handleMessage(<string> message.Body)
+      attributeNames: ['All'],
+      messageAttributeNames: ['compression', 'event'],
+      queueUrl: this.queueUrl,
+      sqs: this.sqs,
+      handleMessage:
+        /* istanbul ignore next */
+        async (message: SQSMessage) => await this.domainEventMessageHandler.handleMessage(<string> message.Body)
     })
 
     sqsConsumer.on('error', this.domainEventMessageHandler.handleError.bind(this.domainEventMessageHandler))


### PR DESCRIPTION
This enforces a 2-space indentation style for all projects using `@standardnotes/config` in versions `1.1.1+`