### PR TITLE
feat: add isSameDay util

### DIFF
--- a/packages/snjs/lib/index.ts
+++ b/packages/snjs/lib/index.ts
@@ -98,6 +98,7 @@ export {
   getGlobalScope,
   greaterOfTwoDates,
   isNullOrUndefined,
+  isSameDay,
   jsonParseEmbeddedKeys,
   omitUndefinedCopy,
   removeFromArray,

--- a/packages/snjs/lib/utils.ts
+++ b/packages/snjs/lib/utils.ts
@@ -487,3 +487,14 @@ export async function sleep(milliseconds: number) {
 export function assertUnreachable(uncheckedCase: never): never {
   throw Error("Unchecked case " + uncheckedCase);
 }
+
+/**
+ * Returns a boolean representing whether two dates are on the same day
+ */
+export function isSameDay(dateA: Date, dateB: Date) {
+  return (
+    dateA.getFullYear() === dateB.getFullYear() &&
+    dateA.getMonth() === dateB.getMonth() &&
+    dateA.getDate() === dateB.getDate()
+  );
+}

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -159,7 +159,7 @@ describe('utils', () => {
   });
 
   describe('isSameDay', () => {
-    it('Returns true if two dates are on the same day', () => {
+    it('returns true if two dates are on the same day', () => {
       const dateA = new Date(2021, 1, 16, 16, 30, 0);
       const dateB = new Date(2021, 1, 16, 17, 30, 0);
 
@@ -167,7 +167,7 @@ describe('utils', () => {
       expect(result).to.equal(true);
     });
 
-    it('Returns false if two dates are not on the same day', () => {
+    it('returns false if two dates are not on the same day', () => {
       const dateA = new Date(2021, 1, 16, 16, 30, 0);
       const dateB = new Date(2021, 1, 17, 17, 30, 0);
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -157,4 +157,22 @@ describe('utils', () => {
     const result = truncateHexString(hex256, desiredBits);
     expect(result.length).to.equal(expectedLength);
   });
+
+  describe('isSameDay', () => {
+    it('Returns true if two dates are on the same day', () => {
+      const dateA = new Date(2021, 1, 16, 16, 30, 0);
+      const dateB = new Date(2021, 1, 16, 17, 30, 0);
+
+      const result = isSameDay(dateA, dateB);
+      expect(result).to.equal(true);
+    });
+
+    it('Returns false if two dates are not on the same day', () => {
+      const dateA = new Date(2021, 1, 16, 16, 30, 0);
+      const dateB = new Date(2021, 1, 17, 17, 30, 0);
+
+      const result = isSameDay(dateA, dateB);
+      expect(result).to.equal(false);
+    });
+  })
 });


### PR DESCRIPTION
Add isSameDay util that returns a boolean indicating whether two dates correspond to the same day. This util is moved here because it's used both for web and mobile.