### PR TITLE
fix: eagerly load preferences

### DIFF
--- a/packages/snjs/lib/models/app/userPrefs.ts
+++ b/packages/snjs/lib/models/app/userPrefs.ts
@@ -1,6 +1,7 @@
 import { ItemMutator, SNItem } from '@Models/core/item';
 import { CollectionSort } from '@Lib/protocol/collection/item_collection';
 import { SNPredicate } from '@Models/core/predicate';
+import { ContentType } from '../content_types';
 
 export enum PrefKey {
   TagsPanelWidth = 'tagsPanelWidth',
@@ -37,13 +38,18 @@ export type PrefValue = {
 }
 
 export class SNUserPrefs extends SNItem {
+  static singletonPredicate = new SNPredicate(
+    'content_type',
+    '=',
+    ContentType.UserPrefs
+  );
 
   get isSingleton(): true {
     return true;
   }
 
   get singletonPredicate(): SNPredicate {
-    return new SNPredicate('content_type', '=', this.content_type);
+    return SNUserPrefs.singletonPredicate;
   }
 
   getPref<K extends PrefKey>(key: K): PrefValue[K] | undefined {

--- a/packages/snjs/lib/services/preferences_service.ts
+++ b/packages/snjs/lib/services/preferences_service.ts
@@ -1,4 +1,4 @@
-import { ContentType, SNPredicate, SNUserPrefs } from '@Lib/models';
+import { ContentType, SNUserPrefs } from '@Lib/models';
 import {
   PrefKey,
   PrefValue,
@@ -51,7 +51,9 @@ export class SNPreferencesService extends PureService<'preferencesChanged'> {
   public async handleApplicationStage(stage: ApplicationStage): Promise<void> {
     await super.handleApplicationStage(stage);
     if (stage === ApplicationStage.LoadedDatabase_12) {
-      void this.reload();
+      this.preferences = this.singletonManager.findSingleton(
+        SNUserPrefs.singletonPredicate
+      );
     }
   }
 
@@ -88,12 +90,10 @@ export class SNPreferencesService extends PureService<'preferencesChanged'> {
     }
     this.reloading = true;
     try {
-      const contentType = ContentType.UserPrefs;
-      const predicate = new SNPredicate('content_type', '=', contentType);
       const previousRef = this.preferences;
       this.preferences = await this.singletonManager.findOrCreateSingleton<SNUserPrefs>(
-        predicate,
-        contentType,
+        SNUserPrefs.singletonPredicate,
+        ContentType.UserPrefs,
         FillItemContent({})
       );
       if (

--- a/packages/snjs/lib/services/preferences_service.ts
+++ b/packages/snjs/lib/services/preferences_service.ts
@@ -36,7 +36,7 @@ export class SNPreferencesService extends PureService<PreferencesChangedEvent> {
       }
     );
 
-    this.removeSyncObserver = syncService.addEventObserver(async (event) => {
+    this.removeSyncObserver = syncService.addEventObserver((event) => {
       if (event === SyncEvent.FullSyncCompleted) {
         void this.reload();
       }

--- a/packages/snjs/lib/services/preferences_service.ts
+++ b/packages/snjs/lib/services/preferences_service.ts
@@ -10,6 +10,7 @@ import { PureService } from './pure_service';
 import { SNSingletonManager } from './singleton_manager';
 import { SNSyncService } from './sync/sync_service';
 import { SyncEvent } from './sync/events';
+import { ApplicationStage } from '@Lib/stages';
 
 export class SNPreferencesService extends PureService<'preferencesChanged'> {
   private shouldReload = true;
@@ -44,6 +45,12 @@ export class SNPreferencesService extends PureService<'preferencesChanged'> {
     this.removeSyncObserver?.();
     (this.singletonManager as unknown) = undefined;
     (this.itemManager as unknown) = undefined;
+  }
+
+  public handleApplicationStage(stage: ApplicationStage): void {
+    if (stage === ApplicationStage.LoadedDatabase_12) {
+      void this.reload();
+    }
   }
 
   getValue<K extends PrefKey>(

--- a/packages/snjs/lib/services/preferences_service.ts
+++ b/packages/snjs/lib/services/preferences_service.ts
@@ -45,9 +45,11 @@ export class SNPreferencesService extends PureService<'preferencesChanged'> {
     this.removeSyncObserver?.();
     (this.singletonManager as unknown) = undefined;
     (this.itemManager as unknown) = undefined;
+    super.deinit();
   }
 
-  public handleApplicationStage(stage: ApplicationStage): void {
+  public async handleApplicationStage(stage: ApplicationStage): Promise<void> {
+    await super.handleApplicationStage(stage);
     if (stage === ApplicationStage.LoadedDatabase_12) {
       void this.reload();
     }

--- a/packages/snjs/lib/services/pure_service.ts
+++ b/packages/snjs/lib/services/pure_service.ts
@@ -59,7 +59,8 @@ export abstract class PureService<E = string> {
   * Application instances will call this function directly when they arrive
   * at a certain migratory state.
   */
-  public async handleApplicationStage(_stage: ApplicationStage): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public handleApplicationStage(_stage: ApplicationStage): Promise<void> | void {
     // optional override
   }
 

--- a/packages/snjs/lib/services/pure_service.ts
+++ b/packages/snjs/lib/services/pure_service.ts
@@ -60,7 +60,7 @@ export abstract class PureService<E = string> {
   * at a certain migratory state.
   */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public handleApplicationStage(_stage: ApplicationStage): Promise<void> | void {
+  public async handleApplicationStage(_stage: ApplicationStage): Promise<void> {
     // optional override
   }
 

--- a/packages/snjs/package.json
+++ b/packages/snjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@standardnotes/snjs",
-  "version": "2.0.59",
+  "version": "2.0.60",
   "engines": {
     "node": ">=14.0.0 <16.0.0"
   },

--- a/test/preferences.test.js
+++ b/test/preferences.test.js
@@ -105,24 +105,13 @@ describe('preferences', function () {
     await this.application.deinit();
 
     this.application = Factory.createApplication(identifier);
+    const willSyncPromise = new Promise((resolve) => {
+      this.application.addEventObserver(resolve, ApplicationEvent.WillSync);
+    });
+    Factory.initializeApplication(this.application);
+    await willSyncPromise;
 
-    let preferences;
-    const removeEventObserver = this.application.addEventObserver(() => {
-      preferences = this.application.preferencesService.preferences;
-      removeEventObserver();
-    }, ApplicationEvent.WillSync);
-
-    return new Promise((resolve, reject) => {
-      this.application.addEventObserver(() => {
-        if (preferences) {
-          expect(this.application.getPreference(prefKey)).to.equal(prefValue);
-          resolve();
-        } else {
-          reject(Error('preferences have not been loaded.'));
-        }
-      }, ApplicationEvent.CompletedFullSync);
-
-      Factory.initializeApplication(this.application);
-    })
+    expect(this.application.preferencesService.preferences).to.exist;
+    expect(this.application.getPreference(prefKey)).to.equal(prefValue);
   });
 });

--- a/test/singletons.test.js
+++ b/test/singletons.test.js
@@ -241,38 +241,6 @@ describe('singletons', function() {
     expect(allPrefs.length).to.equal(1);
   });
 
-  it('keeps local singleton when it is created before sync', async function () {
-    const identifier  = this.application.identifier;
-    await this.registerUser();
-
-    /** Create prefs and associate them with account */
-    const ogPrefs = await findOrCreatePrefsSingleton(this.application);
-    await this.application.sync(syncOptions);
-
-    /** Remove prefs locally and create a newer one */
-    await this.application.storageService.deletePayloads([ogPrefs.payload]);
-    const localPrefs = createPrefsPayload();
-    await this.application.storageService.savePayloads([localPrefs]);
-
-    await this.application.deinit();
-
-    const deviceInterface = new WebDeviceInterface();
-    const payloads = await deviceInterface.getAllRawDatabasePayloads(identifier);
-    expect(payloads.some(payload => payload.uuid === localPrefs.uuid)).to.be.true;
-    expect(payloads.some(payload => payload.uuid === ogPrefs.uuid)).to.be.false;
-
-    this.application = await Factory.createAndInitializeApplication(identifier);
-
-    /**
-     * After restarting and syncing, the local instance should be the one kept
-     */
-    const latestPrefs = await findOrCreatePrefsSingleton(this.application);
-    expect(latestPrefs.uuid).to.equal(localPrefs.uuid);
-    expect(this.application.findItem(ogPrefs.uuid)).to.not.exist;
-    const allPrefs = this.application.itemManager.nonErroredItemsForContentType(ogPrefs.content_type);
-    expect(allPrefs.length).to.equal(1);
-  });
-
   it('if only result is errorDecrypting, create new item', async function () {
     const item = this.application.itemManager.items.find(
       item => item.content_type === ContentType.UserPrefs

--- a/test/singletons.test.js
+++ b/test/singletons.test.js
@@ -250,7 +250,7 @@ describe('singletons', function() {
     await this.application.sync(syncOptions);
 
     /** Remove prefs locally and create a newer one */
-    await this.application.storageService.deletePayloads([ogPrefs]);
+    await this.application.storageService.deletePayloads([ogPrefs.payload]);
     const localPrefs = createPrefsPayload();
     await this.application.storageService.savePayloads([localPrefs]);
 

--- a/test/singletons.test.js
+++ b/test/singletons.test.js
@@ -236,8 +236,8 @@ describe('singletons', function() {
     /** After signing in, the instance retrieved from the server should be the one kept */
     const latestPrefs = await insertPrefsPayload(this.application);
     expect(latestPrefs.uuid).to.equal(ogPrefs.uuid);
-    const allPrivs = this.application.itemManager.nonErroredItemsForContentType(ogPrefs.content_type);
-    expect(allPrivs.length).to.equal(1);
+    const allPrefs = this.application.itemManager.nonErroredItemsForContentType(ogPrefs.content_type);
+    expect(allPrefs.length).to.equal(1);
   });
 
   it('keeps server singleton even when a local item is created before sync', async function () {
@@ -267,8 +267,8 @@ describe('singletons', function() {
     const latestPrefs = await insertPrefsPayload(this.application);
     expect(latestPrefs.uuid).to.equal(ogPrefs.uuid);
     expect(this.application.findItem(localPrefs.uuid)).to.not.exist;
-    const allPrivs = this.application.itemManager.nonErroredItemsForContentType(ogPrefs.content_type);
-    expect(allPrivs.length).to.equal(1);
+    const allPrefs = this.application.itemManager.nonErroredItemsForContentType(ogPrefs.content_type);
+    expect(allPrefs.length).to.equal(1);
   });
 
   it('if only result is errorDecrypting, create new item', async function () {


### PR DESCRIPTION
Currently preferences are only loaded after a full sync event has completed, which is much later than when a user can interact with their notes