### PR TITLE
Add protected encrypted backups

### DIFF
--- a/packages/snjs/lib/application.ts
+++ b/packages/snjs/lib/application.ts
@@ -1051,7 +1051,7 @@ export class SNApplication {
    */
   public async createBackupFile(
     intent: EncryptionIntent,
-    authorizeEncrypted: boolean = false
+    authorizeEncrypted = false
   ): Promise<BackupFile | undefined> {
     const encrypted = intent === EncryptionIntent.FileEncrypted;
     const decrypted = intent === EncryptionIntent.FileDecrypted;

--- a/packages/snjs/lib/application.ts
+++ b/packages/snjs/lib/application.ts
@@ -1050,11 +1050,16 @@ export class SNApplication {
    * Creates a JSON-stringifiable backup object of all items.
    */
   public async createBackupFile(
-    intent: EncryptionIntent
+    intent: EncryptionIntent,
+    authorizeEncrypted: boolean = false
   ): Promise<BackupFile | undefined> {
+    const encrypted = intent === EncryptionIntent.FileEncrypted;
+    const decrypted = intent === EncryptionIntent.FileDecrypted;
+    const authorize = encrypted && authorizeEncrypted || decrypted;
+
     if (
-      intent === EncryptionIntent.FileDecrypted &&
-      !(await this.protectionService.authorizeDecryptedBackupCreation())
+      authorize &&
+      !(await this.protectionService.authorizeBackupCreation(encrypted))
     ) {
       return;
     }

--- a/packages/snjs/lib/challenges.ts
+++ b/packages/snjs/lib/challenges.ts
@@ -35,7 +35,7 @@ export enum ChallengeReason {
   RevokeSession,
   AccessBatchManager,
   ImportEncryptedFile,
-  ExportDecryptedBackup,
+  ExportBackup,
   DisableBiometrics,
   UnprotectNote,
 }
@@ -105,8 +105,8 @@ export class Challenge {
           return ChallengeStrings.AccessBatchManager;
         case ChallengeReason.ImportEncryptedFile:
           return ChallengeStrings.ImportEncryptedFile;
-        case ChallengeReason.ExportDecryptedBackup:
-          return ChallengeStrings.ExportDecryptedBackup;
+        case ChallengeReason.ExportBackup:
+          return ChallengeStrings.ExportBackup;
         case ChallengeReason.DisableBiometrics:
           return ChallengeStrings.DisableBiometrics;
         case ChallengeReason.UnprotectNote:

--- a/packages/snjs/lib/services/api/messages.ts
+++ b/packages/snjs/lib/services/api/messages.ts
@@ -158,7 +158,7 @@ export const ChallengeStrings = {
   AccountPasswordPlaceholder: 'Account Password',
   LocalPasscodePlaceholder: 'Application Passcode',
   ImportEncryptedFile: 'Enter the account password associated with the import file',
-  ExportDecryptedBackup: 'Authentication is required to export a decrypted backup',
+  ExportBackup: 'Authentication is required to export a backup',
   DisableBiometrics: 'Authentication is required to disable biometrics',
   UnprotectNote: 'Authentication is required to unprotect a note',
 }

--- a/packages/snjs/lib/services/protection_service.ts
+++ b/packages/snjs/lib/services/protection_service.ts
@@ -182,9 +182,9 @@ export class SNProtectionService extends PureService<ProtectionEvent.SessionExpi
     return this.validateOrRenewSession(ChallengeReason.ImportFile);
   }
 
-  async authorizeDecryptedBackupCreation(): Promise<boolean> {
-    return this.validateOrRenewSession(ChallengeReason.ExportDecryptedBackup, {
-      fallBackToAccountPassword: false,
+  async authorizeBackupCreation(encrypted: boolean): Promise<boolean> {
+    return this.validateOrRenewSession(ChallengeReason.ExportBackup, {
+      fallBackToAccountPassword: encrypted,
     });
   }
 

--- a/packages/snjs/package.json
+++ b/packages/snjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@standardnotes/snjs",
-  "version": "2.0.60",
+  "version": "2.0.61",
   "engines": {
     "node": ">=14.0.0 <16.0.0"
   },

--- a/test/backups.test.js
+++ b/test/backups.test.js
@@ -37,20 +37,32 @@ describe('backups', function () {
   });
 
   it('no passcode + no account backup file should have correct number of items', async function () {
-    await Factory.createSyncedNote(this.application);
-    await Factory.createSyncedNote(this.application);
+    await Promise.all([
+      Factory.createSyncedNote(this.application),
+      Factory.createSyncedNote(this.application)
+    ]);
     const data = await this.application.createBackupFile(EncryptionIntent.FileDecrypted);
     expect(data.items.length).to.equal(BASE_ITEM_COUNT_DECRYPTED + 2);
   });
 
   it('passcode + no account backup file should have correct number of items', async function () {
-    await this.application.setPasscode('passcode');
+    const passcode = 'passcode';
+    await this.application.setPasscode(passcode);
     await Promise.all([
       Factory.createSyncedNote(this.application),
       Factory.createSyncedNote(this.application)
     ]);
-    const data = await this.application.createBackupFile(EncryptionIntent.FileEncrypted);
-    expect(data.items.length).to.equal(BASE_ITEM_COUNT_ENCRYPTED + 2);
+
+    // Encrypted backup without authorization
+    const encryptedData = await this.application.createBackupFile(EncryptionIntent.FileEncrypted);
+    expect(encryptedData.items.length).to.equal(BASE_ITEM_COUNT_ENCRYPTED + 2);
+
+    // Encrypted backup with authorization
+    Factory.handlePasswordChallenges(this.application, passcode);
+    const authorizedEncryptedData = await this.application.createBackupFile(
+      EncryptionIntent.FileEncrypted,
+      true);
+    expect(authorizedEncryptedData.items.length).to.equal(BASE_ITEM_COUNT_ENCRYPTED + 2);
   });
 
   it('no passcode + account backup file should have correct number of items', async function () {
@@ -59,12 +71,25 @@ describe('backups', function () {
       email: this.email,
       password: this.password,
     });
-    await Factory.createSyncedNote(this.application);
-    await Factory.createSyncedNote(this.application);
-    let data = await this.application.createBackupFile(EncryptionIntent.FileEncrypted);
-    expect(data.items.length).to.equal(BASE_ITEM_COUNT_ENCRYPTED + 2);
-    data = await this.application.createBackupFile(EncryptionIntent.FileDecrypted);
-    expect(data.items.length).to.equal(BASE_ITEM_COUNT_DECRYPTED + 2);
+    await Promise.all([
+      Factory.createSyncedNote(this.application),
+      Factory.createSyncedNote(this.application)
+    ]);
+
+    // Encrypted backup without authorization
+    const encryptedData = await this.application.createBackupFile(EncryptionIntent.FileEncrypted);
+    expect(encryptedData.items.length).to.equal(BASE_ITEM_COUNT_ENCRYPTED + 2);
+
+    // Decrypted backup
+    const decryptedData = await this.application.createBackupFile(EncryptionIntent.FileDecrypted);
+    expect(decryptedData.items.length).to.equal(BASE_ITEM_COUNT_DECRYPTED + 2);
+
+    // Encrypted backup with authorization
+    Factory.handlePasswordChallenges(this.application, this.password);
+    const authorizedEncryptedData = await this.application.createBackupFile(
+      EncryptionIntent.FileEncrypted,
+      true);
+    expect(authorizedEncryptedData.items.length).to.equal(BASE_ITEM_COUNT_ENCRYPTED + 2);
   });
 
   it('passcode + account backup file should have correct number of items', async function () {
@@ -72,17 +97,31 @@ describe('backups', function () {
     const passcode = 'passcode';
     await this.application.register(this.email, this.password);
     await this.application.setPasscode(passcode);
-    Factory.handlePasswordChallenges(this.application, passcode);
-    await Factory.createSyncedNote(this.application);
-    await Factory.createSyncedNote(this.application);
-    let backupData = await this.application.createBackupFile(
+    await Promise.all([
+      Factory.createSyncedNote(this.application),
+      Factory.createSyncedNote(this.application)
+    ]);
+
+    // Encrypted backup without authorization
+    const encryptedData = await this.application.createBackupFile(
       EncryptionIntent.FileEncrypted
     );
-    expect(backupData.items.length).to.equal(BASE_ITEM_COUNT_ENCRYPTED + 2);
-    backupData = await this.application.createBackupFile(
+    expect(encryptedData.items.length).to.equal(BASE_ITEM_COUNT_ENCRYPTED + 2);
+
+    Factory.handlePasswordChallenges(this.application, passcode);
+
+    // Decrypted backup
+    const decryptedData = await this.application.createBackupFile(
       EncryptionIntent.FileDecrypted
     );
-    expect(backupData.items.length).to.equal(BASE_ITEM_COUNT_DECRYPTED + 2);
+    expect(decryptedData.items.length).to.equal(BASE_ITEM_COUNT_DECRYPTED + 2);
+
+    // Encrypted backup with authorization
+    const authorizedEncryptedData = await this.application.createBackupFile(
+      EncryptionIntent.FileEncrypted,
+      true
+    );
+    expect(authorizedEncryptedData.items.length).to.equal(BASE_ITEM_COUNT_ENCRYPTED + 2);
   });
 
   it('backup file item should have correct fields', async function () {


### PR DESCRIPTION
Add authorizedEncrypted parameter to createBackupFile method that defaults to false. When set to true, creating an encrypted backup will be a protected action.