### PR TITLE
fix: broken references to notes in tags when importing backup

### DIFF
--- a/packages/snjs/lib/protocol/payloads/functions.ts
+++ b/packages/snjs/lib/protocol/payloads/functions.ts
@@ -107,7 +107,8 @@ export async function PayloadsByDuplicating(
  */
 export async function PayloadsByAlternatingUuid(
   payload: PurePayload,
-  baseCollection: ImmutablePayloadCollection
+  baseCollection: ImmutablePayloadCollection,
+  updateReferencing = true,
 ) {
   const results = [];
   /**
@@ -126,20 +127,22 @@ export async function PayloadsByAlternatingUuid(
   );
   results.push(copy);
 
-  /**
-   * Get the payloads that make reference to payload and remove
-   * payload as a relationship, instead adding the new copy.
-   */
-  const referencing = baseCollection.elementsReferencingElement(payload);
-  const updatedReferencing = await PayloadsByUpdatingReferences(
-    referencing,
-    [{
-      uuid: copy.uuid!,
-      content_type: copy.content_type!
-    }],
-    [payload.uuid!]
-  );
-  extendArray(results, updatedReferencing);
+  if (updateReferencing) {
+    /**
+     * Get the payloads that make reference to payload and remove
+     * payload as a relationship, instead adding the new copy.
+     */
+    const referencing = baseCollection.elementsReferencingElement(payload);
+    const updatedReferencing = await PayloadsByUpdatingReferences(
+      referencing,
+      [{
+        uuid: copy.uuid!,
+        content_type: copy.content_type!
+      }],
+      [payload.uuid!]
+    );
+    extendArray(results, updatedReferencing);
+  }
 
   const updatedSelf = CopyPayload(
     payload,


### PR DESCRIPTION
Related issue: https://app.asana.com/0/1160981203938995/1199383179826917/f

This fixes the problem of disappearing tags: https://github.com/standardnotes/forum/issues/1179

On my machine the backup file from this issue (https://github.com/standardnotes/forum/files/5745950/backup.zip) imports properly with the correct number of tags and correct references to all notes.

It's a quick fix (first hack that works). I cannot guarantee it doesn't break something else as there is seems to be a lot of dependencies and state in this code and I had no time to understand them.

***

I just noticed that after rebasing to master, there are some errors, probably caused by latest commits. Will fix that later.

In the meantime leaving as is.