### PR TITLE
localStorage repair

### DIFF
--- a/packages/snjs/lib/application.ts
+++ b/packages/snjs/lib/application.ts
@@ -961,7 +961,7 @@ export class SNApplication {
             true
           ),
         ],
-        ChallengeReason.ImportEncryptedFile,
+        ChallengeReason.DecryptEncryptedFile,
         true
       );
       const passwordResponse = await this.challengeService.promptForChallengeResponse(
@@ -978,7 +978,6 @@ export class SNApplication {
     if (!(await this.protectionService.authorizeFileImport())) {
       return;
     }
-
     const decryptedPayloads = await this.protocolService.payloadsByDecryptingBackupFile(
       data,
       password

--- a/packages/snjs/lib/application.ts
+++ b/packages/snjs/lib/application.ts
@@ -101,7 +101,7 @@ import { ProtectionEvent } from './services/protection_service';
 import { Permission } from '@standardnotes/auth';
 
 /** How often to automatically sync, in milliseconds */
-const DEFAULT_AUTO_SYNC_INTERVAL = 30000;
+const DEFAULT_AUTO_SYNC_INTERVAL = 30_000;
 
 type LaunchCallback = {
   receiveChallenge: (challenge: Challenge) => void;
@@ -146,7 +146,7 @@ export class SNApplication {
   private streamRemovers: ObserverRemover[] = [];
   private serviceObservers: ObserverRemover[] = [];
   private managedSubscribers: ObserverRemover[] = [];
-  private autoSyncInterval: any;
+  private autoSyncInterval!: number;
 
   /** True if the result of deviceInterface.openDatabase yields a new database being created */
   private createdNewDatabase = false;
@@ -1283,8 +1283,8 @@ export class SNApplication {
     return this.deinit(DeinitSource.Lock);
   }
 
-  public async setPasscode(passcode: string): Promise<void> {
-    return this.credentialService.setPasscode(passcode);
+  public addPasscode(passcode: string): Promise<boolean> {
+    return this.credentialService.addPasscode(passcode);
   }
 
   /**
@@ -1365,11 +1365,11 @@ export class SNApplication {
     this.createMigrationService();
     this.createHistoryManager();
     this.createSyncManager();
-    this.createAccountSerivce();
+    this.createProtectionService();
+    this.createCredentialService();
     this.createKeyRecoveryService();
     this.createSingletonManager();
     this.createComponentManager();
-    this.createProtectionService();
     this.createActionsManager();
     this.createPreferencesService();
   }
@@ -1423,7 +1423,7 @@ export class SNApplication {
     this.services.push(this.migrationService);
   }
 
-  private createAccountSerivce(): void {
+  private createCredentialService(): void {
     this.credentialService = new SNCredentialService(
       this.sessionManager,
       this.syncService,
@@ -1431,7 +1431,8 @@ export class SNApplication {
       this.itemManager,
       this.protocolService,
       this.alertService,
-      this.challengeService
+      this.challengeService,
+      this.protectionService
     );
     this.services.push(this.credentialService);
   }

--- a/packages/snjs/lib/application.ts
+++ b/packages/snjs/lib/application.ts
@@ -1,3 +1,9 @@
+import {
+  SNCredentialService,
+  PasswordChangeFunctionResponse,
+  AccountServiceResponse,
+  AccountEvent,
+} from './services/credential_service';
 import { NotesDisplayCriteria } from './protocol/collection/notes_display_criteria';
 import { SNKeyRecoveryService } from './services/key_recovery_service';
 import {
@@ -75,25 +81,13 @@ import {
 import { DeviceInterface } from './device_interface';
 import {
   BACKUP_FILE_MORE_RECENT_THAN_ACCOUNT,
-  CHANGING_PASSCODE,
-  ChallengeStrings,
-  DO_NOT_CLOSE_APPLICATION,
   ErrorAlertStrings,
-  INVALID_PASSWORD,
-  InsufficientPasswordMessage,
-  PasswordChangeStrings,
   ProtocolUpgradeStrings,
-  REMOVING_PASSCODE,
-  SETTING_PASSCODE,
   UNSUPPORTED_BACKUP_FILE_VERSION,
-  UPGRADING_ENCRYPTION,
   SessionStrings,
   ImportStrings,
 } from './services/api/messages';
-import {
-  MINIMUM_PASSWORD_LENGTH,
-  SessionEvent,
-} from './services/api/session_manager';
+import { SessionEvent } from './services/api/session_manager';
 import { PrefKey, PrefValue, SNComponent, SNNote, SNTag } from './models';
 import { ProtocolVersion, compareVersions } from './protocol/versions';
 import { KeyParamsOrigination } from './protocol/key_params';
@@ -145,6 +139,7 @@ export class SNApplication {
   private keyRecoveryService!: SNKeyRecoveryService;
   private preferencesService!: SNPreferencesService;
   private permissionsService!: SNPermissionsService;
+  private credentialService!: SNCredentialService;
 
   private eventHandlers: ApplicationObserver[] = [];
   private services: PureService<any, any>[] = [];
@@ -161,8 +156,6 @@ export class SNApplication {
   private launched = false;
   /** Whether the application has been destroyed via .deinit() */
   private dealloced = false;
-  private signingIn = false;
-  private registering = false;
 
   /**
    * @param environment The Environment that identifies your application.
@@ -545,29 +538,29 @@ export class SNApplication {
    * sees of the item.
    */
   public async setItemNeedsSync(item: SNItem, isUserModified = false) {
-    return this.itemManager!.setItemDirty(item.uuid, isUserModified);
+    return this.itemManager.setItemDirty(item.uuid, isUserModified);
   }
 
   public async setItemsNeedsSync(items: SNItem[]) {
-    return this.itemManager!.setItemsDirty(Uuids(items));
+    return this.itemManager.setItemsDirty(Uuids(items));
   }
 
   public async deleteItem(item: SNItem) {
-    await this.itemManager!.setItemToBeDeleted(item.uuid);
+    await this.itemManager.setItemToBeDeleted(item.uuid);
     return this.sync();
   }
 
   public async deleteItemLocally(item: SNItem) {
-    this.itemManager!.removeItemLocally(item);
+    this.itemManager.removeItemLocally(item);
   }
 
   public async emptyTrash() {
-    await this.itemManager!.emptyTrash();
+    await this.itemManager.emptyTrash();
     return this.sync();
   }
 
   public getTrashedItems() {
-    return this.itemManager!.trashedItems;
+    return this.itemManager.trashedItems;
   }
 
   public setDisplayOptions<T extends SNItem>(
@@ -575,16 +568,16 @@ export class SNApplication {
     sortBy?: CollectionSort,
     direction?: SortDirection,
     filter?: (element: T) => boolean
-  ) {
-    this.itemManager!.setDisplayOptions(contentType, sortBy, direction, filter);
+  ): void {
+    this.itemManager.setDisplayOptions(contentType, sortBy, direction, filter);
   }
 
   public setNotesDisplayCriteria(criteria: NotesDisplayCriteria) {
-    this.itemManager!.setNotesDisplayCriteria(criteria);
+    this.itemManager.setNotesDisplayCriteria(criteria);
   }
 
   public getDisplayableItems(contentType: ContentType) {
-    return this.itemManager!.getDisplayableItems(contentType);
+    return this.itemManager.getDisplayableItems(contentType);
   }
 
   /**
@@ -593,9 +586,9 @@ export class SNApplication {
    */
   public async insertItem(item: SNItem) {
     /* First insert the item */
-    const insertedItem = await this.itemManager!.insertItem(item);
+    const insertedItem = await this.itemManager.insertItem(item);
     /* Now change the item so that it's marked as dirty */
-    await this.itemManager!.changeItems([insertedItem.uuid]);
+    await this.itemManager.changeItems([insertedItem.uuid]);
     return this.findItem(item.uuid)!;
   }
 
@@ -604,16 +597,12 @@ export class SNApplication {
    * and performing a sync request.
    */
   public async saveItem(uuid: UuidString) {
-    const item = this.itemManager!.findItem(uuid);
+    const item = this.itemManager.findItem(uuid);
     if (!item) {
       throw Error('Attempting to save non-inserted item');
     }
     if (!item.dirty) {
-      await this.itemManager!.changeItem(
-        uuid,
-        undefined,
-        MutationType.Internal
-      );
+      await this.itemManager.changeItem(uuid, undefined, MutationType.Internal);
     }
     await this.syncService!.sync();
   }
@@ -631,7 +620,7 @@ export class SNApplication {
     if (!isString(uuid)) {
       throw Error('Must use uuid to change item');
     }
-    await this.itemManager!.changeItems(
+    await this.itemManager.changeItems(
       [uuid],
       mutate,
       isUserModified ? MutationType.UserInteraction : undefined,
@@ -651,7 +640,7 @@ export class SNApplication {
     payloadSource?: PayloadSource,
     syncOptions?: SyncOptions
   ) {
-    await this.itemManager!.changeItems(
+    await this.itemManager.changeItems(
       uuids,
       mutate,
       isUserModified ? MutationType.UserInteraction : undefined,
@@ -671,7 +660,7 @@ export class SNApplication {
     if (!isString(uuid)) {
       throw Error('Must use uuid to change item');
     }
-    await this.itemManager!.changeItems(
+    await this.itemManager.changeItems(
       [uuid],
       mutate,
       isUserModified ? MutationType.UserInteraction : undefined
@@ -687,7 +676,7 @@ export class SNApplication {
     mutate?: (mutator: M) => void,
     isUserModified = true
   ) {
-    return this.itemManager!.changeItems(
+    return this.itemManager.changeItems(
       uuids,
       mutate,
       isUserModified ? MutationType.UserInteraction : undefined
@@ -709,16 +698,16 @@ export class SNApplication {
   }
 
   public getItems(contentType: ContentType | ContentType[]) {
-    return this.itemManager!.getItems(contentType);
+    return this.itemManager.getItems(contentType);
   }
 
   public notesMatchingSmartTag(smartTag: SNSmartTag) {
-    return this.itemManager!.notesMatchingSmartTag(smartTag);
+    return this.itemManager.notesMatchingSmartTag(smartTag);
   }
 
   /** Returns an item's direct references */
   public referencesForItem(item: SNItem, contentType?: ContentType) {
-    let references = this.itemManager!.referencesForItem(item.uuid);
+    let references = this.itemManager.referencesForItem(item.uuid);
     if (contentType) {
       references = references.filter((ref) => {
         return ref?.content_type === contentType;
@@ -729,7 +718,7 @@ export class SNApplication {
 
   /** Returns items referencing an item */
   public referencingForItem(item: SNItem, contentType?: ContentType): SNItem[] {
-    let references = this.itemManager!.itemsReferencingItem(item.uuid);
+    let references = this.itemManager.itemsReferencingItem(item.uuid);
     if (contentType) {
       references = references.filter((ref) => {
         return ref?.content_type === contentType;
@@ -752,19 +741,19 @@ export class SNApplication {
   }
 
   public findTagByTitle(title: string): SNTag | undefined {
-    return this.itemManager!.findTagByTitle(title);
+    return this.itemManager.findTagByTitle(title);
   }
 
   public async findOrCreateTag(title: string): Promise<SNTag> {
-    return this.itemManager!.findOrCreateTagByTitle(title);
+    return this.itemManager.findOrCreateTagByTitle(title);
   }
 
   public getSmartTags(): SNSmartTag[] {
-    return this.itemManager!.getSmartTags();
+    return this.itemManager.getSmartTags();
   }
 
   public getNoteCount(): number {
-    return this.itemManager!.noteCount;
+    return this.itemManager.noteCount;
   }
 
   /**
@@ -776,7 +765,7 @@ export class SNApplication {
     contentType: ContentType | ContentType[],
     stream: ItemStream
   ): () => void {
-    const observer = this.itemManager!.addObserver(
+    const observer = this.itemManager.addObserver(
       contentType,
       (changed, inserted, discarded, _ignored, source) => {
         const all = changed.concat(inserted).concat(discarded);
@@ -784,7 +773,7 @@ export class SNApplication {
       }
     );
     /** Push current values now */
-    const matches = this.itemManager!.getItems(contentType);
+    const matches = this.itemManager.getItems(contentType);
     if (matches.length > 0) {
       stream(matches);
     }
@@ -844,89 +833,6 @@ export class SNApplication {
     return this.hasAccount() || this.hasPasscode();
   }
 
-  private async performProtocolUpgrade(): Promise<{
-    success?: true;
-    canceled?: true;
-    error?: { message: string };
-  }> {
-    const hasPasscode = this.hasPasscode();
-    const hasAccount = this.hasAccount();
-    const prompts = [];
-    if (hasPasscode) {
-      prompts.push(
-        new ChallengePrompt(
-          ChallengeValidation.LocalPasscode,
-          undefined,
-          ChallengeStrings.LocalPasscodePlaceholder
-        )
-      );
-    }
-    if (hasAccount) {
-      prompts.push(
-        new ChallengePrompt(
-          ChallengeValidation.AccountPassword,
-          undefined,
-          ChallengeStrings.AccountPasswordPlaceholder
-        )
-      );
-    }
-    const challenge = new Challenge(
-      prompts,
-      ChallengeReason.ProtocolUpgrade,
-      true
-    );
-    const response = await this.challengeService.promptForChallengeResponse(
-      challenge
-    );
-    if (!response) {
-      return { canceled: true };
-    }
-    const dismissBlockingDialog = await this.alertService.blockingDialog(
-      DO_NOT_CLOSE_APPLICATION,
-      UPGRADING_ENCRYPTION
-    );
-    try {
-      let passcode: string | undefined;
-      if (hasPasscode) {
-        /* Upgrade passcode version */
-        const value = response.getValueForType(
-          ChallengeValidation.LocalPasscode
-        );
-        passcode = value.value as string;
-      }
-      if (hasAccount) {
-        /* Upgrade account version */
-        const value = response.getValueForType(
-          ChallengeValidation.AccountPassword
-        );
-        const password = value.value as string;
-        const changeResponse = await this.changePassword(
-          password,
-          password,
-          passcode,
-          KeyParamsOrigination.ProtocolUpgrade,
-          { validatePasswordStrength: false }
-        );
-        if (changeResponse?.error) {
-          return { error: changeResponse.error };
-        }
-      }
-      if (hasPasscode) {
-        /* Upgrade passcode version */
-        await this.removePasscodeWithoutWarning();
-        await this.setPasscodeWithoutWarning(
-          passcode!,
-          KeyParamsOrigination.ProtocolUpgrade
-        );
-      }
-      return { success: true };
-    } catch (error) {
-      return { error };
-    } finally {
-      dismissBlockingDialog();
-    }
-  }
-
   public async upgradeProtocolVersion(): Promise<{
     success?: true;
     canceled?: true;
@@ -934,7 +840,7 @@ export class SNApplication {
       message: string;
     };
   }> {
-    const result = await this.performProtocolUpgrade();
+    const result = await this.credentialService.performProtocolUpgrade();
     if (result.success) {
       if (this.hasAccount()) {
         void this.alertService.alert(ProtocolUpgradeStrings.SuccessAccount);
@@ -1136,16 +1042,8 @@ export class SNApplication {
     return this.protocolService.createBackupFile(intent);
   }
 
-  public isEphemeralSession() {
-    return this.storageService!.isEphemeralSession();
-  }
-
-  private lockSyncing() {
-    this.syncService!.lockSyncing();
-  }
-
-  private unlockSyncing() {
-    this.syncService!.unlockSyncing();
+  public isEphemeralSession(): boolean {
+    return this.storageService.isEphemeralSession();
   }
 
   public sync(options?: SyncOptions): Promise<any> {
@@ -1200,28 +1098,6 @@ export class SNApplication {
 
   public hasPermission(permission: Permission): boolean {
     return this.permissionsService.hasPermission(permission);
-  }
-
-  /**
-   * Deletes all payloads from storage.
-   */
-  public async clearDatabase(): Promise<void> {
-    return this.storageService.clearAllPayloads();
-  }
-
-  /**
-   * Allows items keys to be rewritten to local db on local credential status change,
-   * such as if passcode is added, changed, or removed.
-   * This allows IndexedDB unencrypted logs to be deleted
-   * `deletePayloads` will remove data from backing store,
-   * but not from working memory See:
-   * https://github.com/standardnotes/desktop/issues/131
-   */
-  private async rewriteItemsKeys() {
-    const itemsKeys = this.itemManager.itemsKeys();
-    const payloads = itemsKeys.map((key) => key.payloadRepresentation());
-    await this.storageService.deletePayloads(payloads);
-    await this.syncService.persistPayloads(payloads);
   }
 
   /**
@@ -1295,7 +1171,6 @@ export class SNApplication {
     this.clearServices();
     this.dealloced = true;
     this.started = false;
-    this.signingIn = false;
   }
 
   /**
@@ -1307,45 +1182,8 @@ export class SNApplication {
     password: string,
     ephemeral = false,
     mergeLocal = true
-  ) {
-    if (this.hasAccount()) {
-      throw Error('Tried to register when an account already exists.');
-    }
-    if (this.registering) {
-      throw Error('Already registering.');
-    }
-    this.registering = true;
-    try {
-      this.lockSyncing();
-      const result = await this.sessionManager.register(
-        email,
-        password,
-        ephemeral
-      );
-      if (!result.response.error) {
-        this.syncService!.resetSyncState();
-        await this.storageService!.setPersistencePolicy(
-          ephemeral
-            ? StoragePersistencePolicies.Ephemeral
-            : StoragePersistencePolicies.Default
-        );
-        if (mergeLocal) {
-          await this.syncService!.markAllItemsAsNeedingSync(true);
-        } else {
-          this.itemManager!.removeAllItemsFromMemory();
-          await this.clearDatabase();
-        }
-        await this.notifyEvent(ApplicationEvent.SignedIn);
-        this.unlockSyncing();
-        await this.syncService.downloadFirstSync(300);
-        this.protocolService.decryptErroredItems();
-      } else {
-        this.unlockSyncing();
-      }
-      return result.response;
-    } finally {
-      this.registering = false;
-    }
+  ): Promise<AccountServiceResponse> {
+    return this.credentialService.register(email, password, ephemeral, mergeLocal);
   }
 
   /**
@@ -1359,157 +1197,35 @@ export class SNApplication {
     ephemeral = false,
     mergeLocal = true,
     awaitSync = false
-  ) {
-    if (this.hasAccount()) {
-      throw Error('Tried to sign in when an account already exists.');
-    }
-    if (this.signingIn) {
-      throw Error('Already signing in.');
-    }
-    this.signingIn = true;
-    try {
-      /** Prevent a timed sync from occuring while signing in. */
-      this.lockSyncing();
-      const result = await this.sessionManager.signIn(
-        email,
-        password,
-        strict,
-        ephemeral
-      );
-      if (!result.response.error) {
-        this.syncService.resetSyncState();
-        await this.storageService.setPersistencePolicy(
-          ephemeral
-            ? StoragePersistencePolicies.Ephemeral
-            : StoragePersistencePolicies.Default
-        );
-        if (mergeLocal) {
-          await this.syncService.markAllItemsAsNeedingSync(true);
-        } else {
-          void this.itemManager.removeAllItemsFromMemory();
-          await this.clearDatabase();
-        }
-        await this.notifyEvent(ApplicationEvent.SignedIn);
-        this.unlockSyncing();
-        const syncPromise = this.syncService.downloadFirstSync(1_000, {
-          checkIntegrity: true,
-          awaitAll: awaitSync,
-        });
-        if (awaitSync) {
-          await syncPromise;
-          await this.protocolService.decryptErroredItems();
-        } else {
-          this.protocolService.decryptErroredItems();
-        }
-      } else {
-        this.unlockSyncing();
-      }
-      return result.response;
-    } finally {
-      this.signingIn = false;
-    }
+  ): Promise<AccountServiceResponse> {
+    return this.credentialService.signIn(
+      email,
+      password,
+      strict,
+      ephemeral,
+      mergeLocal,
+      awaitSync
+    );
   }
 
-  /**
-   * @param passcode - Changing the account password requires the local
-   * passcode if configured (to rewrap the account key with passcode). If the passcode
-   * is not passed in, the user will be prompted for the passcode. However if the consumer
-   * already has reference to the passcode, they can pass it in here so that the user
-   * is not prompted again.
-   */
   public async changePassword(
     currentPassword: string,
     newPassword: string,
     passcode?: string,
     origination = KeyParamsOrigination.PasswordChange,
     { validatePasswordStrength = true } = {}
-  ) {
-    const result = await this.performPasswordChange(
+  ): Promise<PasswordChangeFunctionResponse> {
+    return this.credentialService.changePassword(
       currentPassword,
       newPassword,
       passcode,
       origination,
       { validatePasswordStrength }
     );
-    if (result.error) {
-      void this.alertService.alert(result.error.message);
-    }
-    return result;
-  }
-
-  private async performPasswordChange(
-    currentPassword: string,
-    newPassword: string,
-    passcode?: string,
-    origination = KeyParamsOrigination.PasswordChange,
-    { validatePasswordStrength = true } = {}
-  ): Promise<{ error?: { message: string } }> {
-    const {
-      wrappingKey,
-      canceled,
-    } = await this.challengeService.getWrappingKeyIfApplicable(passcode);
-    if (canceled) {
-      return { error: Error(PasswordChangeStrings.PasscodeRequired) };
-    }
-    if (validatePasswordStrength) {
-      if (newPassword.length < MINIMUM_PASSWORD_LENGTH) {
-        return {
-          error: Error(InsufficientPasswordMessage(MINIMUM_PASSWORD_LENGTH)),
-        };
-      }
-    }
-    const accountPasswordValidation = await this.protocolService.validateAccountPassword(
-      currentPassword
-    );
-    if (!accountPasswordValidation.valid) {
-      return {
-        error: Error(INVALID_PASSWORD),
-      };
-    }
-    /** Current root key must be recomputed as persisted value does not contain server password */
-    const currentRootKey = await this.protocolService.computeRootKey(
-      currentPassword,
-      (await this.protocolService.getRootKeyParams())!
-    );
-    const newRootKey = await this.protocolService.createRootKey(
-      this.getUser()!.email!,
-      newPassword,
-      origination
-    );
-    this.lockSyncing();
-    /** Now, change the password on the server. Roll back on failure */
-    const result = await this.sessionManager.changePassword(
-      currentRootKey.serverPassword!,
-      newRootKey,
-      wrappingKey
-    );
-    this.unlockSyncing();
-    if (!result.response.error) {
-      const rollback = await this.protocolService.createNewItemsKeyWithRollback();
-      /** Sync the newly created items key. Roll back on failure */
-      await this.protocolService.reencryptItemsKeys();
-      await this.syncService.sync({ awaitAll: true });
-      const itemsKeyWasSynced = !this.protocolService.getDefaultItemsKey()!
-        .neverSynced;
-      if (!itemsKeyWasSynced) {
-        await this.sessionManager.changePassword(
-          newRootKey.serverPassword!,
-          currentRootKey,
-          wrappingKey
-        );
-        await this.protocolService.reencryptItemsKeys();
-        await rollback();
-        await this.syncService.sync({ awaitAll: true });
-        return { error: Error(PasswordChangeStrings.Failed) };
-      }
-    }
-    return result.response;
   }
 
   public async signOut(): Promise<void> {
-    await this.sessionManager.signOut();
-    await this.protocolService.clearLocalKeyState();
-    await this.storageService.clearAllData();
+    await this.credentialService.signOut();
     await this.notifyEvent(ApplicationEvent.SignedOut);
     await this.prepareForDeinit();
     this.deinit(DeinitSource.SignOut);
@@ -1567,93 +1283,22 @@ export class SNApplication {
     return this.deinit(DeinitSource.Lock);
   }
 
-  /**
-   * @returns whether the passcode was successfuly added or not
-   */
-  public async addPasscode(passcode: string): Promise<boolean> {
-    if (!(await this.protectionService.authorizeAddingPasscode())) {
-      return false;
-    }
-
-    const dismissBlockingDialog = await this.alertService.blockingDialog(
-      DO_NOT_CLOSE_APPLICATION,
-      SETTING_PASSCODE
-    );
-    try {
-      await this.setPasscodeWithoutWarning(
-        passcode,
-        KeyParamsOrigination.PasscodeCreate
-      );
-      return true;
-    } finally {
-      dismissBlockingDialog();
-    }
+  public async setPasscode(passcode: string): Promise<void> {
+    return this.credentialService.setPasscode(passcode);
   }
 
   /**
-   * @returns whether the passcode was successfuly removed or not
+   * @returns whether the passcode was successfuly removed
    */
   public async removePasscode(): Promise<boolean> {
-    if (!(await this.protectionService.authorizeRemovingPasscode())) {
-      return false;
-    }
-
-    const dismissBlockingDialog = await this.alertService.blockingDialog(
-      DO_NOT_CLOSE_APPLICATION,
-      REMOVING_PASSCODE
-    );
-    try {
-      await this.removePasscodeWithoutWarning();
-      return true;
-    } finally {
-      dismissBlockingDialog();
-    }
+    return this.credentialService.removePasscode();
   }
 
-  /**
-   * @returns whether the passcode was successfuly changed or not
-   */
   public async changePasscode(
     newPasscode: string,
     origination = KeyParamsOrigination.PasscodeChange
   ): Promise<boolean> {
-    if (!(await this.protectionService.authorizeChangingPasscode())) {
-      return false;
-    }
-
-    const dismissBlockingDialog = await this.alertService.blockingDialog(
-      DO_NOT_CLOSE_APPLICATION,
-      origination === KeyParamsOrigination.ProtocolUpgrade
-        ? ProtocolUpgradeStrings.UpgradingPasscode
-        : CHANGING_PASSCODE
-    );
-    try {
-      await this.removePasscodeWithoutWarning();
-      await this.setPasscodeWithoutWarning(newPasscode, origination);
-      return true;
-    } finally {
-      dismissBlockingDialog();
-    }
-  }
-
-  private async setPasscodeWithoutWarning(
-    passcode: string,
-    origination: KeyParamsOrigination
-  ) {
-    const identifier = await this.generateUuid();
-    const key = await this.protocolService.createRootKey(
-      identifier,
-      passcode,
-      origination
-    );
-    await this.protocolService.setNewRootKeyWrapper(key);
-    await this.rewriteItemsKeys();
-    await this.syncService.sync();
-  }
-
-  private async removePasscodeWithoutWarning() {
-    await this.protocolService.removeRootKeyWrapper();
-    await this.rewriteItemsKeys();
+    return this.credentialService.changePasscode(newPasscode, origination);
   }
 
   public getStorageEncryptionPolicy(): StorageEncryptionPolicies {
@@ -1720,6 +1365,7 @@ export class SNApplication {
     this.createMigrationService();
     this.createHistoryManager();
     this.createSyncManager();
+    this.createAccountSerivce();
     this.createKeyRecoveryService();
     this.createSingletonManager();
     this.createComponentManager();
@@ -1748,6 +1394,7 @@ export class SNApplication {
     (this.keyRecoveryService as unknown) = undefined;
     (this.preferencesService as unknown) = undefined;
     (this.permissionsService as unknown) = undefined;
+    (this.credentialService as unknown) = undefined;
 
     this.services = [];
   }
@@ -1774,6 +1421,19 @@ export class SNApplication {
       identifier: this.identifier,
     });
     this.services.push(this.migrationService);
+  }
+
+  private createAccountSerivce(): void {
+    this.credentialService = new SNCredentialService(
+      this.sessionManager,
+      this.syncService,
+      this.storageService,
+      this.itemManager,
+      this.protocolService,
+      this.alertService,
+      this.challengeService
+    );
+    this.services.push(this.credentialService);
   }
 
   private createApiService() {
@@ -1854,12 +1514,12 @@ export class SNApplication {
       this.itemManager,
       this.payloadManager,
       this.apiService,
-      this.sessionManager,
       this.protocolService,
       this.challengeService,
       this.alertService,
       this.storageService,
-      this.syncService
+      this.syncService,
+      this.credentialService
     );
     this.services.push(this.keyRecoveryService);
   }
@@ -1970,6 +1630,19 @@ export class SNApplication {
       this.payloadManager,
       this.protocolService,
       this.syncService
+    );
+    this.serviceObservers.push(
+      this.credentialService.addEventObserver((event) => {
+        switch (event) {
+          case AccountEvent.SignedInOrRegistered: {
+            void this.notifyEvent(ApplicationEvent.SignedIn);
+            break;
+          }
+          default: {
+            assertUnreachable(event);
+          }
+        }
+      })
     );
     this.services.push(this.actionsManager);
   }

--- a/packages/snjs/lib/application.ts
+++ b/packages/snjs/lib/application.ts
@@ -309,7 +309,7 @@ export class SNApplication {
         }
         await this.handleStage(ApplicationStage.LoadedDatabase_12);
         this.beginAutoSyncTimer();
-        return this.syncService.sync({
+        await this.syncService.sync({
           mode: SyncModes.DownloadFirst,
         });
       });
@@ -1183,7 +1183,12 @@ export class SNApplication {
     ephemeral = false,
     mergeLocal = true
   ): Promise<AccountServiceResponse> {
-    return this.credentialService.register(email, password, ephemeral, mergeLocal);
+    return this.credentialService.register(
+      email,
+      password,
+      ephemeral,
+      mergeLocal
+    );
   }
 
   /**
@@ -1539,7 +1544,7 @@ export class SNApplication {
           case SessionEvent.Restored: {
             void (async () => {
               await this.sync();
-              if (await this.protocolService.needsNewRootKeyBasedItemsKey()) {
+              if (this.protocolService.needsNewRootKeyBasedItemsKey()) {
                 void this.protocolService.createNewDefaultItemsKey();
               }
             })();

--- a/packages/snjs/lib/challenges.ts
+++ b/packages/snjs/lib/challenges.ts
@@ -36,7 +36,7 @@ export enum ChallengeReason {
   RevokeSession,
   AccessBatchManager,
   AccessCloudLink,
-  ImportEncryptedFile,
+  DecryptEncryptedFile,
   ExportBackup,
   DisableBiometrics,
   UnprotectNote,
@@ -110,8 +110,8 @@ export class Challenge {
           return ChallengeStrings.AccessBatchManager;
         case ChallengeReason.AccessCloudLink:
           return ChallengeStrings.AccessCloudLink;
-        case ChallengeReason.ImportEncryptedFile:
-          return ChallengeStrings.ImportEncryptedFile;
+        case ChallengeReason.DecryptEncryptedFile:
+          return ChallengeStrings.DecryptEncryptedFile;
         case ChallengeReason.ExportBackup:
           return ChallengeStrings.ExportBackup;
         case ChallengeReason.DisableBiometrics:

--- a/packages/snjs/lib/device_interface.ts
+++ b/packages/snjs/lib/device_interface.ts
@@ -26,8 +26,8 @@ export abstract class DeviceInterface {
   }
 
   public deinit() {
-    this.timeout = null;
-    this.interval = null;
+    this.timeout = undefined;
+    this.interval = undefined;
   }
 
   abstract getRawStorageValue(key: string): Promise<string | undefined>;

--- a/packages/snjs/lib/migrations/2_0_15.ts
+++ b/packages/snjs/lib/migrations/2_0_15.ts
@@ -14,7 +14,7 @@ export class Migration2_0_15 extends Migration {
   }
 
   private async createNewDefaultItemsKeyIfNecessary() {
-    if (await this.services.protocolService.needsNewRootKeyBasedItemsKey()) {
+    if (this.services.protocolService.needsNewRootKeyBasedItemsKey()) {
       await this.services.protocolService.createNewDefaultItemsKey();
     }
   }

--- a/packages/snjs/lib/models/core/item.ts
+++ b/packages/snjs/lib/models/core/item.ts
@@ -325,7 +325,6 @@ export class SNItem {
       'references',
     ]);
     if (itemsAreDifferentExcludingRefs) {
-      const twentySeconds = 20_000;
       if (previousRevision) {
         /**
          * If previousRevision.content === incomingValue.content, this means the
@@ -338,6 +337,7 @@ export class SNItem {
           return ConflictStrategy.KeepLeft;
         }
       }
+      const twentySeconds = 20_000;
       if (
         /**
          * If the incoming item comes from an import, treat it as

--- a/packages/snjs/lib/models/core/item.ts
+++ b/packages/snjs/lib/models/core/item.ts
@@ -264,7 +264,7 @@ export class SNItem {
   }
 
   /** Whether the item has never been synced to a server */
-  public get neverSynced() {
+  public get neverSynced(): boolean {
     return !this.serverUpdatedAt || this.serverUpdatedAt.getTime() === 0;
   }
 
@@ -272,7 +272,7 @@ export class SNItem {
    * Subclasses can override this getter to return true if they want only
    * one of this item to exist, depending on custom criteria.
    */
-  public get isSingleton() {
+  public get isSingleton(): boolean {
     return false;
   }
 
@@ -281,8 +281,16 @@ export class SNItem {
     throw 'Must override SNItem.singletonPredicate';
   }
 
-  public get singletonStrategy() {
+  public get singletonStrategy(): SingletonStrategy {
     return SingletonStrategy.KeepEarliest;
+  }
+
+  /**
+   * An item is syncable if it not errored. If it is, it is only syncable if it is being deleted.
+   * Otherwise, we don't want to save corrupted content locally or send it to the server.
+   */
+  public get isSyncable(): boolean {
+    return !this.errorDecrypting || this.deleted === true;
   }
 
   /**

--- a/packages/snjs/lib/protocol/payloads/deltas/remote_retrieved.ts
+++ b/packages/snjs/lib/protocol/payloads/deltas/remote_retrieved.ts
@@ -35,7 +35,7 @@ export class DeltaRemoteRetrieved extends PayloadsDelta {
         continue;
       }
       const base = this.findBasePayload(received.uuid!);
-      if (base && base.dirty) {
+      if (base?.dirty && !base.errorDecrypting) {
         conflicted.push(decrypted);
         continue;
       }

--- a/packages/snjs/lib/protocol/payloads/deltas/remote_retrieved.ts
+++ b/packages/snjs/lib/protocol/payloads/deltas/remote_retrieved.ts
@@ -6,7 +6,7 @@ import { extendArray } from '@Lib/utils';
 import { PurePayload } from '../pure_payload';
 
 export class DeltaRemoteRetrieved extends PayloadsDelta {
-  public async resultingCollection() {
+  public async resultingCollection(): Promise<ImmutablePayloadCollection> {
     const filtered = [];
     const conflicted = [];
     /**
@@ -15,11 +15,11 @@ export class DeltaRemoteRetrieved extends PayloadsDelta {
      */
     for (const received of this.applyCollection.all()) {
       const savedOrSaving = this.findRelatedPayload(
-        received.uuid!,
+        received.uuid as string,
         PayloadSource.SavedOrSaving
       );
       const decrypted = this.findRelatedPayload(
-        received.uuid!,
+        received.uuid as string,
         PayloadSource.DecryptedTransient
       );
       if (!decrypted) {
@@ -34,7 +34,7 @@ export class DeltaRemoteRetrieved extends PayloadsDelta {
         conflicted.push(decrypted);
         continue;
       }
-      const base = this.findBasePayload(received.uuid!);
+      const base = this.findBasePayload(received.uuid as string);
       if (base?.dirty && !base.errorDecrypting) {
         conflicted.push(decrypted);
         continue;

--- a/packages/snjs/lib/protocol/payloads/functions.ts
+++ b/packages/snjs/lib/protocol/payloads/functions.ts
@@ -59,7 +59,10 @@ export async function PayloadsByDuplicating(
   baseCollection: ImmutablePayloadCollection,
   isConflict: boolean,
   additionalContent?: Partial<PayloadContent>
-) {
+): Promise<PurePayload> {
+  if (payload.errorDecrypting) {
+    throw Error('Attempting to duplicate errored payload');
+  }
   const results = [];
   const override: PayloadOverride = {
     uuid: await Uuid.GenerateUuid(),

--- a/packages/snjs/lib/protocol/payloads/functions.ts
+++ b/packages/snjs/lib/protocol/payloads/functions.ts
@@ -115,7 +115,7 @@ export async function PayloadsByDuplicating(
 export async function PayloadsByAlternatingUuid(
   payload: PurePayload,
   baseCollection: ImmutablePayloadCollection
-) {
+): Promise<PurePayload[]> {
   const results = [];
   /**
    * We need to clone payload and give it a new uuid,
@@ -127,6 +127,7 @@ export async function PayloadsByAlternatingUuid(
     dirtiedDate: new Date(),
     lastSyncBegan: null,
     lastSyncEnd: null,
+    duplicate_of: payload.uuid,
   });
   results.push(copy);
 
@@ -146,6 +147,21 @@ export async function PayloadsByAlternatingUuid(
     [payload.uuid!]
   );
   extendArray(results, updatedReferencing);
+
+  if (payload.content_type === ContentType.ItemsKey) {
+    /**
+     * Update any payloads who are still encrypted and whose items_key_id point to this uuid
+     */
+    const matchingPayloads = baseCollection
+      .all()
+      .filter((p) => p.items_key_id === payload.uuid);
+    const adjustedPayloads = matchingPayloads.map((a) =>
+      CopyPayload(a, { items_key_id: copy.uuid })
+    );
+    if (adjustedPayloads.length > 0) {
+      extendArray(results, adjustedPayloads);
+    }
+  }
 
   const updatedSelf = CopyPayload(payload, {
     deleted: true,

--- a/packages/snjs/lib/protocol/payloads/functions.ts
+++ b/packages/snjs/lib/protocol/payloads/functions.ts
@@ -59,7 +59,7 @@ export async function PayloadsByDuplicating(
   baseCollection: ImmutablePayloadCollection,
   isConflict: boolean,
   additionalContent?: Partial<PayloadContent>
-): Promise<PurePayload> {
+): Promise<PurePayload[]> {
   if (payload.errorDecrypting) {
     throw Error('Attempting to duplicate errored payload');
   }

--- a/packages/snjs/lib/services/api/messages.ts
+++ b/packages/snjs/lib/services/api/messages.ts
@@ -203,7 +203,7 @@ export const ChallengeStrings = {
     'Enter your credentials to download a decrypted backup',
   AccountPasswordPlaceholder: 'Account Password',
   LocalPasscodePlaceholder: 'Application Passcode',
-  ImportEncryptedFile:
+  DecryptEncryptedFile:
     'Enter the account password associated with the import file',
   ExportBackup: 'Authentication is required to export a backup',
   DisableBiometrics: 'Authentication is required to disable biometrics',

--- a/packages/snjs/lib/services/api/responses.ts
+++ b/packages/snjs/lib/services/api/responses.ts
@@ -72,11 +72,16 @@ export type KeyParamsResponse = HttpResponse & {
   created?: string;
 };
 
+export type User = {
+  uuid: string;
+  email: string;
+};
+
 export type RegistrationResponse = HttpResponse & {
   session?: SessionBody;
   /** Represents legacy JWT token */
   token?: string;
-  user?: { email: string; uuid: string };
+  user?: User;
 };
 
 export type SignInResponse = RegistrationResponse & {

--- a/packages/snjs/lib/services/api/session_manager.ts
+++ b/packages/snjs/lib/services/api/session_manager.ts
@@ -15,10 +15,13 @@ import {
   RegistrationResponse,
   SignInResponse,
   StatusCode,
+  User,
 } from './responses';
 import { SNProtocolService } from './../protocol_service';
 import { SNApiService } from './api_service';
-import { SNStorageService } from './../storage_service';
+import {
+  SNStorageService,
+} from './../storage_service';
 import { SNRootKey } from '@Protocol/root_key';
 import {
   AnyKeyParamsContent,
@@ -47,11 +50,6 @@ type SessionManagerResponse = {
   response: HttpResponse;
   rootKey?: SNRootKey;
   keyParams?: AnyKeyParamsContent;
-};
-
-type User = {
-  uuid: string;
-  email?: string;
 };
 
 const cleanedEmailString = (email: string) => {
@@ -104,7 +102,7 @@ export class SNSessionManager extends PureService<SessionEvent> {
       /** @legacy Check for uuid. */
       const uuid = await this.storageService!.getValue(StorageKey.LegacyUuid);
       if (uuid) {
-        this.user = { uuid: uuid };
+        this.user = { uuid: uuid, email: uuid };
       }
     }
 

--- a/packages/snjs/lib/services/component_manager.ts
+++ b/packages/snjs/lib/services/component_manager.ts
@@ -1514,16 +1514,16 @@ export class SNComponentManager extends PureService {
    */
   private deregisterComponent(uuid: UuidString) {
     this.log('Degregistering component', uuid);
-    const component = this.findComponent(uuid);
     delete this.componentState[uuid];
-    const area = component.area;
     this.streamObservers = this.streamObservers.filter((o) => {
       return o.componentUuid !== uuid;
     });
     this.contextStreamObservers = this.contextStreamObservers.filter((o) => {
       return o.componentUuid !== uuid;
     });
-    if (area === ComponentArea.Themes) {
+
+    const component = this.findComponent(uuid);
+    if (component?.area === ComponentArea.Themes) {
       this.postActiveThemesToAllComponents();
     }
   }

--- a/packages/snjs/lib/services/credential_service.ts
+++ b/packages/snjs/lib/services/credential_service.ts
@@ -1,0 +1,505 @@
+import { Uuid } from '@Lib/uuid';
+import { isNullOrUndefined } from '@Lib/utils';
+import {
+  Challenge,
+  ChallengeReason,
+  ChallengeValidation,
+} from './../challenges';
+import { ChallengePrompt } from '@Lib/challenges';
+import { SNRootKey } from '@Protocol/root_key';
+import { SNAlertService } from '@Services/alert_service';
+import {
+  KeyParamsOrigination,
+  SNRootKeyParams,
+} from './../protocol/key_params';
+import {
+  PasswordChangeStrings,
+  INVALID_PASSWORD,
+  InsufficientPasswordMessage,
+  ChallengeStrings,
+  DO_NOT_CLOSE_APPLICATION,
+  UPGRADING_ENCRYPTION,
+  SETTING_PASSCODE,
+  REMOVING_PASSCODE,
+  CHANGING_PASSCODE,
+  ProtocolUpgradeStrings,
+} from './api/messages';
+import { HttpResponse, SignInResponse, User } from './api/responses';
+import { SNProtocolService } from '@Lib/services/protocol_service';
+import { ItemManager } from '@Services/item_manager';
+import {
+  SNStorageService,
+  StoragePersistencePolicies,
+} from '@Services/storage_service';
+import { SNSyncService } from './sync/sync_service';
+import {
+  SNSessionManager,
+  MINIMUM_PASSWORD_LENGTH,
+} from './api/session_manager';
+import { PureService } from '@Services/pure_service';
+import { ChallengeService } from './challenge/challenge_service';
+import { SNItemsKey } from '@Lib/models';
+
+export type PasswordChangeFunctionResponse = { error?: { message: string } };
+export type AccountServiceResponse = HttpResponse<unknown>;
+
+export const enum AccountEvent {
+  SignedInOrRegistered = 'SignedInOrRegistered',
+}
+
+export class SNCredentialService extends PureService<AccountEvent> {
+  private signingIn = false;
+  private registering = false;
+
+  constructor(
+    private sessionManager: SNSessionManager,
+    private syncService: SNSyncService,
+    private storageService: SNStorageService,
+    private itemManager: ItemManager,
+    private protocolService: SNProtocolService,
+    private alertService: SNAlertService,
+    private challengeService: ChallengeService
+  ) {
+    super();
+  }
+
+  public deinit(): void {
+    super.deinit();
+    (this.sessionManager as unknown) = undefined;
+    (this.syncService as unknown) = undefined;
+    (this.storageService as unknown) = undefined;
+    (this.itemManager as unknown) = undefined;
+    (this.protocolService as unknown) = undefined;
+    (this.alertService as unknown) = undefined;
+    (this.challengeService as unknown) = undefined;
+  }
+
+  /**
+   *  @param mergeLocal  Whether to merge existing offline data into account. If false,
+   *                     any pre-existing data will be fully deleted upon success.
+   */
+  public async register(
+    email: string,
+    password: string,
+    ephemeral = false,
+    mergeLocal = true
+  ): Promise<AccountServiceResponse> {
+    if (this.protocolService.hasAccount()) {
+      throw Error('Tried to register when an account already exists.');
+    }
+    if (this.registering) {
+      throw Error('Already registering.');
+    }
+    this.registering = true;
+    try {
+      this.lockSyncing();
+      const result = await this.sessionManager.register(
+        email,
+        password,
+        ephemeral
+      );
+      if (!result.response.error) {
+        this.syncService.resetSyncState();
+        await this.storageService.setPersistencePolicy(
+          ephemeral
+            ? StoragePersistencePolicies.Ephemeral
+            : StoragePersistencePolicies.Default
+        );
+        if (mergeLocal) {
+          await this.syncService.markAllItemsAsNeedingSync(true);
+        } else {
+          this.itemManager.removeAllItemsFromMemory();
+          await this.clearDatabase();
+        }
+        await this.notifyEvent(AccountEvent.SignedInOrRegistered);
+        this.unlockSyncing();
+        await this.syncService.downloadFirstSync(300);
+        this.protocolService.decryptErroredItems();
+      } else {
+        this.unlockSyncing();
+      }
+      return result.response;
+    } finally {
+      this.registering = false;
+    }
+  }
+
+  /**
+   * @param mergeLocal  Whether to merge existing offline data into account.
+   * If false, any pre-existing data will be fully deleted upon success.
+   */
+  public async signIn(
+    email: string,
+    password: string,
+    strict = false,
+    ephemeral = false,
+    mergeLocal = true,
+    awaitSync = false
+  ): Promise<AccountServiceResponse> {
+    if (this.protocolService.hasAccount()) {
+      throw Error('Tried to sign in when an account already exists.');
+    }
+    if (this.signingIn) {
+      throw Error('Already signing in.');
+    }
+    this.signingIn = true;
+    try {
+      /** Prevent a timed sync from occuring while signing in. */
+      this.lockSyncing();
+      const result = await this.sessionManager.signIn(
+        email,
+        password,
+        strict,
+        ephemeral
+      );
+      if (!result.response.error) {
+        this.syncService.resetSyncState();
+        await this.storageService.setPersistencePolicy(
+          ephemeral
+            ? StoragePersistencePolicies.Ephemeral
+            : StoragePersistencePolicies.Default
+        );
+        if (mergeLocal) {
+          await this.syncService.markAllItemsAsNeedingSync(true);
+        } else {
+          void this.itemManager.removeAllItemsFromMemory();
+          await this.clearDatabase();
+        }
+        await this.notifyEvent(AccountEvent.SignedInOrRegistered);
+        this.unlockSyncing();
+        const syncPromise = this.syncService.downloadFirstSync(1_000, {
+          checkIntegrity: true,
+          awaitAll: awaitSync,
+        });
+        if (awaitSync) {
+          await syncPromise;
+          await this.protocolService.decryptErroredItems();
+        } else {
+          this.protocolService.decryptErroredItems();
+        }
+      } else {
+        this.unlockSyncing();
+      }
+      return result.response;
+    } finally {
+      this.signingIn = false;
+    }
+  }
+
+  /**
+   * A sign in request that occurs while the user was previously signed in, to correct
+   * for missing keys or storage values.
+   */
+  public async correctiveSignIn(rootKey: SNRootKey): Promise<SignInResponse> {
+    this.lockSyncing();
+    const response = await this.sessionManager.bypassChecksAndSignInWithRootKey(
+      rootKey.keyParams.identifier,
+      rootKey
+    );
+    if (!response.error) {
+      await this.notifyEvent(AccountEvent.SignedInOrRegistered);
+      this.unlockSyncing();
+      this.syncService.downloadFirstSync(1_000, {
+        checkIntegrity: true,
+      });
+      this.protocolService.decryptErroredItems();
+    }
+    this.unlockSyncing();
+    return response;
+  }
+
+  /**
+   * @param passcode - Changing the account password requires the local
+   * passcode if configured (to rewrap the account key with passcode). If the passcode
+   * is not passed in, the user will be prompted for the passcode. However if the consumer
+   * already has reference to the passcode, they can pass it in here so that the user
+   * is not prompted again.
+   */
+  public async changePassword(
+    currentPassword: string,
+    newPassword: string,
+    passcode?: string,
+    origination = KeyParamsOrigination.PasswordChange,
+    { validatePasswordStrength = true } = {}
+  ): Promise<PasswordChangeFunctionResponse> {
+    const result = await this.performPasswordChange(
+      currentPassword,
+      newPassword,
+      passcode,
+      origination,
+      { validatePasswordStrength }
+    );
+    if (result.error) {
+      void this.alertService.alert(result.error.message);
+    }
+    return result;
+  }
+
+  private async performPasswordChange(
+    currentPassword: string,
+    newPassword: string,
+    passcode?: string,
+    origination = KeyParamsOrigination.PasswordChange,
+    { validatePasswordStrength = true } = {}
+  ): Promise<PasswordChangeFunctionResponse> {
+    const {
+      wrappingKey,
+      canceled,
+    } = await this.challengeService.getWrappingKeyIfApplicable(passcode);
+    if (canceled) {
+      return { error: Error(PasswordChangeStrings.PasscodeRequired) };
+    }
+    if (validatePasswordStrength) {
+      if (newPassword.length < MINIMUM_PASSWORD_LENGTH) {
+        return {
+          error: Error(InsufficientPasswordMessage(MINIMUM_PASSWORD_LENGTH)),
+        };
+      }
+    }
+    const accountPasswordValidation = await this.protocolService.validateAccountPassword(
+      currentPassword
+    );
+    if (!accountPasswordValidation.valid) {
+      return {
+        error: Error(INVALID_PASSWORD),
+      };
+    }
+    /** Current root key must be recomputed as persisted value does not contain server password */
+    const currentRootKey = await this.protocolService.computeRootKey(
+      currentPassword,
+      (await this.protocolService.getRootKeyParams()) as SNRootKeyParams
+    );
+    const user = this.sessionManager.getUser() as User;
+    const newRootKey = await this.protocolService.createRootKey(
+      user.email,
+      newPassword,
+      origination
+    );
+    this.lockSyncing();
+    /** Now, change the password on the server. Roll back on failure */
+    const result = await this.sessionManager.changePassword(
+      currentRootKey.serverPassword as string,
+      newRootKey,
+      wrappingKey
+    );
+    this.unlockSyncing();
+    if (!result.response.error) {
+      const rollback = await this.protocolService.createNewItemsKeyWithRollback();
+      /** Sync the newly created items key. Roll back on failure */
+      await this.protocolService.reencryptItemsKeys();
+      await this.syncService.sync({ awaitAll: true });
+      const defaultItemsKey = this.protocolService.getDefaultItemsKey() as SNItemsKey;
+      const itemsKeyWasSynced = !defaultItemsKey.neverSynced;
+      if (!itemsKeyWasSynced) {
+        await this.sessionManager.changePassword(
+          newRootKey.serverPassword as string,
+          currentRootKey,
+          wrappingKey
+        );
+        await this.protocolService.reencryptItemsKeys();
+        await rollback();
+        await this.syncService.sync({ awaitAll: true });
+        return { error: Error(PasswordChangeStrings.Failed) };
+      }
+    }
+    return result.response;
+  }
+
+  public async signOut(): Promise<void> {
+    await this.sessionManager.signOut();
+    await this.protocolService.clearLocalKeyState();
+    await this.storageService.clearAllData();
+  }
+
+  public async performProtocolUpgrade(): Promise<{
+    success?: true;
+    canceled?: true;
+    error?: { message: string };
+  }> {
+    const hasPasscode = this.protocolService.hasPasscode();
+    const hasAccount = this.protocolService.hasAccount();
+    const prompts = [];
+    if (hasPasscode) {
+      prompts.push(
+        new ChallengePrompt(
+          ChallengeValidation.LocalPasscode,
+          undefined,
+          ChallengeStrings.LocalPasscodePlaceholder
+        )
+      );
+    }
+    if (hasAccount) {
+      prompts.push(
+        new ChallengePrompt(
+          ChallengeValidation.AccountPassword,
+          undefined,
+          ChallengeStrings.AccountPasswordPlaceholder
+        )
+      );
+    }
+    const challenge = new Challenge(
+      prompts,
+      ChallengeReason.ProtocolUpgrade,
+      true
+    );
+    const response = await this.challengeService.promptForChallengeResponse(
+      challenge
+    );
+    if (!response) {
+      return { canceled: true };
+    }
+    const dismissBlockingDialog = await this.alertService.blockingDialog(
+      DO_NOT_CLOSE_APPLICATION,
+      UPGRADING_ENCRYPTION
+    );
+    try {
+      let passcode: string | undefined;
+      if (hasPasscode) {
+        /* Upgrade passcode version */
+        const value = response.getValueForType(
+          ChallengeValidation.LocalPasscode
+        );
+        passcode = value.value as string;
+      }
+      if (hasAccount) {
+        /* Upgrade account version */
+        const value = response.getValueForType(
+          ChallengeValidation.AccountPassword
+        );
+        const password = value.value as string;
+        const changeResponse = await this.changePassword(
+          password,
+          password,
+          passcode,
+          KeyParamsOrigination.ProtocolUpgrade,
+          { validatePasswordStrength: false }
+        );
+        if (changeResponse?.error) {
+          return { error: changeResponse.error };
+        }
+      }
+      if (hasPasscode) {
+        /* Upgrade passcode version */
+        await this.changePasscode(
+          passcode as string,
+          KeyParamsOrigination.ProtocolUpgrade
+        );
+      }
+      return { success: true };
+    } catch (error) {
+      return { error };
+    } finally {
+      dismissBlockingDialog();
+    }
+  }
+
+  public async setPasscode(passcode: string): Promise<void> {
+    const dismissBlockingDialog = await this.alertService.blockingDialog(
+      DO_NOT_CLOSE_APPLICATION,
+      SETTING_PASSCODE
+    );
+    try {
+      await this.setPasscodeWithoutWarning(
+        passcode,
+        KeyParamsOrigination.PasscodeCreate
+      );
+    } finally {
+      dismissBlockingDialog();
+    }
+  }
+
+  public async removePasscode(): Promise<boolean> {
+    const passcode = await this.challengeService.promptForCorrectPasscode(
+      ChallengeReason.RemovePasscode
+    );
+    if (isNullOrUndefined(passcode)) return false;
+
+    const dismissBlockingDialog = await this.alertService.blockingDialog(
+      DO_NOT_CLOSE_APPLICATION,
+      REMOVING_PASSCODE
+    );
+    try {
+      await this.removePasscodeWithoutWarning();
+      return true;
+    } finally {
+      dismissBlockingDialog();
+    }
+  }
+
+  /**
+   * @returns whether the passcode was successfuly changed or not
+   */
+  public async changePasscode(
+    newPasscode: string,
+    origination = KeyParamsOrigination.PasscodeChange
+  ): Promise<boolean> {
+    const passcode = await this.challengeService.promptForCorrectPasscode(
+      ChallengeReason.ChangePasscode
+    );
+    if (isNullOrUndefined(passcode)) return false;
+
+    const dismissBlockingDialog = await this.alertService.blockingDialog(
+      DO_NOT_CLOSE_APPLICATION,
+      origination === KeyParamsOrigination.ProtocolUpgrade
+        ? ProtocolUpgradeStrings.UpgradingPasscode
+        : CHANGING_PASSCODE
+    );
+    try {
+      await this.removePasscodeWithoutWarning();
+      await this.setPasscodeWithoutWarning(
+        newPasscode,
+        KeyParamsOrigination.PasscodeChange
+      );
+      return true;
+    } finally {
+      dismissBlockingDialog();
+    }
+  }
+
+  private async setPasscodeWithoutWarning(
+    passcode: string,
+    origination: KeyParamsOrigination
+  ) {
+    const identifier = await Uuid.GenerateUuid();
+    const key = await this.protocolService.createRootKey(
+      identifier,
+      passcode,
+      origination
+    );
+    await this.protocolService.setNewRootKeyWrapper(key);
+    await this.rewriteItemsKeys();
+    await this.syncService.sync();
+  }
+
+  private async removePasscodeWithoutWarning() {
+    await this.protocolService.removeRootKeyWrapper();
+    await this.rewriteItemsKeys();
+  }
+
+  /**
+   * Allows items keys to be rewritten to local db on local credential status change,
+   * such as if passcode is added, changed, or removed.
+   * This allows IndexedDB unencrypted logs to be deleted
+   * `deletePayloads` will remove data from backing store,
+   * but not from working memory See:
+   * https://github.com/standardnotes/desktop/issues/131
+   */
+  private async rewriteItemsKeys() {
+    const itemsKeys = this.itemManager.itemsKeys();
+    const payloads = itemsKeys.map((key) => key.payloadRepresentation());
+    await this.storageService.deletePayloads(payloads);
+    await this.syncService.persistPayloads(payloads);
+  }
+
+  private lockSyncing(): void {
+    this.syncService.lockSyncing();
+  }
+
+  private unlockSyncing(): void {
+    this.syncService.unlockSyncing();
+  }
+
+  private async clearDatabase(): Promise<void> {
+    return this.storageService.clearAllPayloads();
+  }
+}

--- a/packages/snjs/lib/services/credential_service.ts
+++ b/packages/snjs/lib/services/credential_service.ts
@@ -109,7 +109,7 @@ export class SNCredentialService extends PureService<AccountEvent> {
             : StoragePersistencePolicies.Default
         );
         if (mergeLocal) {
-          await this.syncService.markAllItemsAsNeedingSync(true);
+          await this.syncService.markAllItemsAsNeedingSync();
         } else {
           this.itemManager.removeAllItemsFromMemory();
           await this.clearDatabase();
@@ -163,7 +163,7 @@ export class SNCredentialService extends PureService<AccountEvent> {
             : StoragePersistencePolicies.Default
         );
         if (mergeLocal) {
-          await this.syncService.markAllItemsAsNeedingSync(false);
+          await this.syncService.markAllItemsAsNeedingSync();
         } else {
           void this.itemManager.removeAllItemsFromMemory();
           await this.clearDatabase();

--- a/packages/snjs/lib/services/credential_service.ts
+++ b/packages/snjs/lib/services/credential_service.ts
@@ -195,7 +195,8 @@ export class SNCredentialService extends PureService<AccountEvent> {
 
   /**
    * A sign in request that occurs while the user was previously signed in, to correct
-   * for missing keys or storage values.
+   * for missing keys or storage values. Unlike regular sign in, this doesn't worry about
+   * performing one of marking all items as needing sync or deleting all local data.
    */
   public async correctiveSignIn(rootKey: SNRootKey): Promise<SignInResponse> {
     this.lockSyncing();
@@ -206,10 +207,10 @@ export class SNCredentialService extends PureService<AccountEvent> {
     if (!response.error) {
       await this.notifyEvent(AccountEvent.SignedInOrRegistered);
       this.unlockSyncing();
-      this.syncService.downloadFirstSync(1_000, {
+      void this.syncService.downloadFirstSync(1_000, {
         checkIntegrity: true,
       });
-      this.protocolService.decryptErroredItems();
+      void this.protocolService.decryptErroredItems();
     }
     this.unlockSyncing();
     return response;

--- a/packages/snjs/lib/services/item_manager.ts
+++ b/packages/snjs/lib/services/item_manager.ts
@@ -540,12 +540,10 @@ export class ItemManager extends PureService {
   /**
    * Returns an array of items that need to be synced.
    */
-  public getDirtyItems() {
+  public getDirtyItems(): SNItem[] {
     const dirty = this.collection.dirtyElements();
     return dirty.filter((item) => {
-      /* An item that has an error decrypting can be synced only if it is being deleted.
-        Otherwise, we don't want to send corrupt content up to the server. */
-      return !item.errorDecrypting || item.deleted;
+      return item.isSyncable;
     });
   }
 

--- a/packages/snjs/lib/services/key_recovery_service.ts
+++ b/packages/snjs/lib/services/key_recovery_service.ts
@@ -356,9 +356,9 @@ export class SNKeyRecoveryService extends PureService {
 
     const hasAccount = this.protocolService.hasAccount();
     const hasPasscode = this.protocolService.hasPasscode();
-    const localStorageMissing = !hasAccount && !hasPasscode;
+    const credentialsMissing = !hasAccount && !hasPasscode;
     let queueItem = this.decryptionQueue[0];
-    if (localStorageMissing) {
+    if (credentialsMissing) {
       const rootKey = await this.performServerSignIn(queueItem.keyParams);
       if (rootKey) {
         await this.handleDecryptionOfAllKeysMatchingCorrectRootKey(

--- a/packages/snjs/lib/services/key_recovery_service.ts
+++ b/packages/snjs/lib/services/key_recovery_service.ts
@@ -1,3 +1,5 @@
+import { SNCredentialService } from './credential_service';
+import { PurePayload } from '@Payloads/pure_payload';
 import { SNSyncService } from './sync/sync_service';
 import { PayloadField } from './../protocol/payloads/fields';
 import { CreateItemFromPayload } from '@Models/generator';
@@ -7,7 +9,6 @@ import { CreateMaxPayloadFromAnyObject, RawPayload } from '@Payloads/generator';
 import { KeyRecoveryStrings } from './api/messages';
 import { SNStorageService, StorageValueModes } from './storage_service';
 import { SNRootKeyParams } from './../protocol/key_params';
-import { SNSessionManager } from './api/session_manager';
 import { PayloadManager } from './payload_manager';
 import {
   Challenge,
@@ -92,12 +93,12 @@ export class SNKeyRecoveryService extends PureService {
     private itemManager: ItemManager,
     private payloadManager: PayloadManager,
     private apiService: SNApiService,
-    private sessionManager: SNSessionManager,
     private protocolService: SNProtocolService,
     private challengeService: ChallengeService,
     private alertService: SNAlertService,
     private storageService: SNStorageService,
-    private syncService: SNSyncService
+    private syncService: SNSyncService,
+    private credentialService: SNCredentialService
   ) {
     super();
     this.removeItemObserver = this.itemManager.addObserver(
@@ -119,14 +120,16 @@ export class SNKeyRecoveryService extends PureService {
     );
   }
 
-  public deinit() {
-    (this.itemManager as any) = undefined;
-    (this.payloadManager as any) = undefined;
-    (this.apiService as any) = undefined;
-    (this.sessionManager as any) = undefined;
-    (this.protocolService as any) = undefined;
-    (this.challengeService as any) = undefined;
-    (this.alertService as any) = undefined;
+  public deinit(): void {
+    (this.itemManager as unknown) = undefined;
+    (this.payloadManager as unknown) = undefined;
+    (this.apiService as unknown) = undefined;
+    (this.protocolService as unknown) = undefined;
+    (this.challengeService as unknown) = undefined;
+    (this.alertService as unknown) = undefined;
+    (this.credentialService as unknown) = undefined;
+    (this.syncService as unknown) = undefined;
+    (this.storageService as unknown) = undefined;
     this.removeItemObserver();
     this.removeItemObserver = undefined;
     super.deinit();
@@ -241,7 +244,9 @@ export class SNKeyRecoveryService extends PureService {
     );
   }
 
-  private async performServerSignIn(keyParams: SNRootKeyParams): Promise<void> {
+  private async performServerSignIn(
+    keyParams: SNRootKeyParams
+  ): Promise<SNRootKey | undefined> {
     /** Get the user's account password */
     const challenge = new Challenge(
       [
@@ -261,7 +266,7 @@ export class SNKeyRecoveryService extends PureService {
       challenge
     );
     if (!challengeResponse) {
-      return;
+      return undefined;
     }
     this.challengeService.completeChallenge(challenge);
     const password = challengeResponse.values[0].value as string;
@@ -270,12 +275,10 @@ export class SNKeyRecoveryService extends PureService {
       password,
       keyParams
     );
-    const signInResponse = await this.sessionManager.bypassChecksAndSignInWithRootKey(
-      keyParams.identifier,
-      rootKey
-    );
+    const signInResponse = await this.credentialService.correctiveSignIn(rootKey);
     if (!signInResponse.error) {
       this.alertService.alert(KeyRecoveryStrings.KeyRecoveryRootKeyReplaced);
+      return rootKey;
     } else {
       await this.alertService.alert(
         KeyRecoveryStrings.KeyRecoveryLoginFlowInvalidPassword
@@ -351,7 +354,21 @@ export class SNKeyRecoveryService extends PureService {
       }
     }
 
+    const hasAccount = this.protocolService.hasAccount();
+    const hasPasscode = this.protocolService.hasPasscode();
+    const localStorageMissing = !hasAccount && !hasPasscode;
     let queueItem = this.decryptionQueue[0];
+    if (localStorageMissing) {
+      const rootKey = await this.performServerSignIn(queueItem.keyParams);
+      if (rootKey) {
+        await this.handleDecryptionOfAllKeysMatchingCorrectRootKey(
+          rootKey,
+          true
+        );
+        removeFromArray(this.decryptionQueue, queueItem);
+        queueItem = this.decryptionQueue[0];
+      }
+    }
     while (queueItem) {
       this.popQueueItem(queueItem);
       await queueItem.promise!;
@@ -390,6 +407,7 @@ export class SNKeyRecoveryService extends PureService {
     const keyParams = queueItem.keyParams;
     const key = queueItem.key;
     const resolve = queueItem.resolve!;
+
     /**
      * We replace our current root key if the server params differ from our own params,
      * and if we can validate the params based on this items key's params.
@@ -456,27 +474,11 @@ export class SNKeyRecoveryService extends PureService {
     /** If it succeeds, re-emit this items key */
     if (!decryptedPayload.errorDecrypting) {
       /** Decrypt and remove from queue any other items keys who share these key params */
-      const matching = this.popQueueForKeyParams(keyParams);
-      const decryptedMatching = await this.protocolService.payloadsByDecryptingPayloads(
-        matching.map((m) => m.key.payload),
-        rootKey
+      const matching = await this.handleDecryptionOfAllKeysMatchingCorrectRootKey(
+        rootKey,
+        replacesRootKey,
+        [decryptedPayload]
       );
-      const allRelevantKeyPayloads = [decryptedPayload].concat(
-        decryptedMatching
-      );
-      this.payloadManager.emitPayloads(
-        allRelevantKeyPayloads,
-        PayloadSource.DecryptedTransient
-      );
-      await this.storageService.savePayloads(allRelevantKeyPayloads);
-      if (replacesRootKey) {
-        /** Replace our root key with the generated root key */
-        const wrappingKey = await this.getWrappingKeyIfApplicable();
-        await this.protocolService.setRootKey(rootKey, wrappingKey);
-        this.alertService.alert(KeyRecoveryStrings.KeyRecoveryRootKeyReplaced);
-      } else {
-        this.alertService.alert(KeyRecoveryStrings.KeyRecoveryKeyRecovered);
-      }
       const result = { success: true };
       resolve(result);
       queueItem.callback?.(key, result);
@@ -492,6 +494,33 @@ export class SNKeyRecoveryService extends PureService {
       this.readdQueueItem(queueItem);
       resolve({ success: false });
     }
+  }
+
+  private async handleDecryptionOfAllKeysMatchingCorrectRootKey(
+    rootKey: SNRootKey,
+    replacesRootKey: boolean,
+    additionalKeys: PurePayload[] = []
+  ) {
+    const matching = this.popQueueForKeyParams(rootKey.keyParams);
+    const decryptedMatching = await this.protocolService.payloadsByDecryptingPayloads(
+      matching.map((m) => m.key.payload),
+      rootKey
+    );
+    const allRelevantKeyPayloads = additionalKeys.concat(decryptedMatching);
+    this.payloadManager.emitPayloads(
+      allRelevantKeyPayloads,
+      PayloadSource.DecryptedTransient
+    );
+    await this.storageService.savePayloads(allRelevantKeyPayloads);
+    if (replacesRootKey) {
+      /** Replace our root key with the generated root key */
+      const wrappingKey = await this.getWrappingKeyIfApplicable();
+      await this.protocolService.setRootKey(rootKey, wrappingKey);
+      this.alertService.alert(KeyRecoveryStrings.KeyRecoveryRootKeyReplaced);
+    } else {
+      this.alertService.alert(KeyRecoveryStrings.KeyRecoveryKeyRecovered);
+    }
+    return matching;
   }
 
   private popQueueForKeyParams(keyParams: SNRootKeyParams) {

--- a/packages/snjs/lib/services/protocol_service.ts
+++ b/packages/snjs/lib/services/protocol_service.ts
@@ -152,6 +152,7 @@ export class SNProtocolService
       enumerable: false,
       writable: true,
     });
+
     this.removeItemsObserver = this.itemManager.addObserver(
       [ContentType.ItemsKey],
       (changed, inserted) => {
@@ -1229,9 +1230,12 @@ export class SNProtocolService
     }
     const payloadVersion = payload.version!;
     if (payloadVersion === this.getLatestVersion()) {
-      throw Error(
-        'No associated key found for item encrypted with latest protocol version.'
+      SNLog.error(
+        Error(
+          'No associated key found for item encrypted with latest protocol version.'
+        )
       );
+      return undefined;
     }
     return this.defaultItemsKeyForItemVersion(payloadVersion);
   }

--- a/packages/snjs/lib/services/singleton_manager.ts
+++ b/packages/snjs/lib/services/singleton_manager.ts
@@ -173,14 +173,7 @@ export class SNSingletonManager extends PureService {
      * of a download-first request.
      */
     if (handled.length > 0 && eventSource === SyncEvent.FullSyncCompleted) {
-      /**
-       * Do not await. We want any local-side changes to
-       * be awaited but the actual sync shouldn't be since it's non-essential
-       * Perform after timeout so that we can yield to event notifier that triggered us
-       */
-      setTimeout(() => {
-        this.syncService?.sync();
-      });
+      await this.syncService?.sync();
     }
   }
 

--- a/packages/snjs/lib/services/sync/account/operation.ts
+++ b/packages/snjs/lib/services/sync/account/operation.ts
@@ -11,12 +11,7 @@ export const SyncUpDownLimit = 150;
  * emitting a stream of values that should be acted upon in real time.
  */
 export class AccountSyncOperation {
-  private payloads: PurePayload[];
-  private receiver: ResponseSignalReceiver;
-  private lastSyncToken: string;
-  private paginationToken: string;
-  public checkIntegrity: boolean;
-  private apiService: SNApiService;
+  public id = Math.random();
 
   private pendingPayloads: PurePayload[];
   private responses: SyncResponse[] = [];
@@ -26,12 +21,12 @@ export class AccountSyncOperation {
    * @param receiver   A function that receives callback multiple times during the operation
    */
   constructor(
-    payloads: PurePayload[],
-    receiver: ResponseSignalReceiver,
-    lastSyncToken: string,
-    paginationToken: string,
-    checkIntegrity: boolean,
-    apiService: SNApiService
+    private payloads: PurePayload[],
+    private receiver: ResponseSignalReceiver,
+    private lastSyncToken: string,
+    private paginationToken: string,
+    public checkIntegrity: boolean,
+    private apiService: SNApiService
   ) {
     this.payloads = payloads;
     this.lastSyncToken = lastSyncToken;

--- a/packages/snjs/lib/services/sync/sync_op_status.ts
+++ b/packages/snjs/lib/services/sync/sync_op_status.ts
@@ -81,7 +81,7 @@ export class SyncOpStatus {
   /**
    * Notifies receiver if current sync request is taking too long to complete.
    */
-  startTimingMonitor() {
+  startTimingMonitor(): void {
     if (this.timingMonitor) {
       this.stopTimingMonitor();
     }
@@ -93,7 +93,7 @@ export class SyncOpStatus {
     }, TIMING_MONITOR_POLL_FREQUENCY_MS);
   }
 
-  stopTimingMonitor() {
+  stopTimingMonitor(): void {
     if (Object.prototype.hasOwnProperty.call(this.interval, 'cancel')) {
       this.interval.cancel(this.timingMonitor);
     } else {
@@ -102,11 +102,11 @@ export class SyncOpStatus {
     this.timingMonitor = null;
   }
 
-  hasError() {
+  hasError(): boolean {
     return !!this.error;
   }
 
-  setError(error: any) {
+  setError(error: any): void {
     this.error = error;
   }
 

--- a/packages/snjs/lib/services/sync/sync_service.ts
+++ b/packages/snjs/lib/services/sync/sync_service.ts
@@ -534,7 +534,7 @@ export class SNSyncService extends PureService<
       this.syncLock = false;
     };
 
-    const syncInProgress = this.opStatus!.syncInProgress;
+    const syncInProgress = this.opStatus.syncInProgress;
     const databaseLoaded = this.databaseLoaded;
     const canExecuteSync = !syncLocked();
     if (canExecuteSync && databaseLoaded && !syncInProgress) {

--- a/packages/snjs/lib/services/sync/sync_service.ts
+++ b/packages/snjs/lib/services/sync/sync_service.ts
@@ -944,7 +944,7 @@ export class SNSyncService extends PureService<
     }
     return this.storageService.savePayloads(payloads).catch((error) => {
       this.notifyEvent(SyncEvent.DatabaseWriteError, error);
-      throw error;
+      SNLog.error(error);
     });
   }
 

--- a/packages/snjs/lib/services/sync/utils.ts
+++ b/packages/snjs/lib/services/sync/utils.ts
@@ -9,10 +9,11 @@ import { PurePayload } from '@Payloads/pure_payload';
 export function SortPayloadsByRecentAndContentPriority(
   payloads: PurePayload[],
   priorityList: ContentType[]
-) {
+): PurePayload[] {
   return payloads.sort((a: PurePayload, b: PurePayload) => {
     const dateResult =
-      new Date(b.serverUpdatedAt!).getTime() - new Date(a.serverUpdatedAt!).getTime();
+      new Date(b.serverUpdatedAt!).getTime() -
+      new Date(a.serverUpdatedAt!).getTime();
     let aPriority = 0;
     let bPriority = 0;
     if (priorityList) {

--- a/test/auth-fringe-cases.test.js
+++ b/test/auth-fringe-cases.test.js
@@ -1,0 +1,144 @@
+/* eslint-disable no-unused-expressions */
+/* eslint-disable no-undef */
+import * as Factory from './lib/factory.js';
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+describe('auth fringe cases', () => {
+  const BASE_ITEM_COUNT = ['default items key', 'user prefs'].length;
+
+  const syncOptions = {
+    checkIntegrity: true,
+    awaitAll: true,
+  };
+
+  const createContext = async () => {
+    const application = await Factory.createInitAppWithRandNamespace();
+    return {
+      expectedItemCount: BASE_ITEM_COUNT,
+      application: application,
+      email: Uuid.GenerateUuidSynchronously(),
+      password: Uuid.GenerateUuidSynchronously(),
+      deinit: () => {
+        application.deinit();
+      },
+    };
+  };
+
+  beforeEach(async function () {
+    localStorage.clear();
+  });
+
+  afterEach(async function () {
+    localStorage.clear();
+  });
+
+  const clearApplicationLocalStorage = function () {
+    const keys = Object.keys(localStorage);
+    for (const key of keys) {
+      if (!key.toLowerCase().includes('item')) {
+        localStorage.removeItem(key);
+      }
+    }
+  };
+
+  const awaitSync = true;
+
+  describe('localStorage improperly cleared with 1 item', function () {
+    it('item should be errored', async function () {
+      const context = await createContext();
+      await context.application.register(context.email, context.password);
+      const note = await Factory.createSyncedNote(context.application);
+      clearApplicationLocalStorage();
+      console.warn(
+        "Expecting errors 'Unable to find operator for version undefined'"
+      );
+      const restartedApplication = await Factory.restartApplication(
+        context.application
+      );
+      const refreshedNote = restartedApplication.itemManager.findItem(
+        note.uuid
+      );
+      expect(refreshedNote.errorDecrypting).to.equal(true);
+      restartedApplication.deinit();
+    });
+
+    it('signing in again should decrypt item', async function () {
+      const context = await createContext();
+      await context.application.register(context.email, context.password);
+      const note = await Factory.createSyncedNote(context.application);
+      clearApplicationLocalStorage();
+      const restartedApplication = await Factory.restartApplication(
+        context.application
+      );
+      console.warn(
+        "Expecting errors 'No associated key found for item encrypted with latest protocol version.'"
+      );
+      await restartedApplication.signIn(
+        context.email,
+        context.password,
+        undefined,
+        undefined,
+        undefined,
+        awaitSync
+      );
+      const refreshedNote = restartedApplication.itemManager.findItem(
+        note.uuid
+      );
+      expect(refreshedNote.errorDecrypting).to.equal(false);
+      restartedApplication.deinit();
+    }).timeout(10000);
+  });
+
+  describe('having offline item matching remote item uuid', function () {
+    it('offline item should not overwrite recently updated server item and conflict should be created', async function () {
+      const context = await createContext();
+      await context.application.register(context.email, context.password);
+      const staleText = 'stale text';
+      const firstVersionOfNote = await Factory.createSyncedNote(
+        context.application,
+        undefined,
+        staleText
+      );
+      const serverText = 'server text';
+      await context.application.changeAndSaveItem(
+        firstVersionOfNote.uuid,
+        (mutator) => {
+          mutator.text = serverText;
+        }
+      );
+      const newApplication = await Factory.signOutApplicationAndReturnNew(
+        context.application
+      );
+      /** Create same note but now offline */
+      await newApplication.itemManager.emitItemFromPayload(
+        firstVersionOfNote.payload
+      );
+
+      /** Sign in and merge local data */
+      await newApplication.signIn(
+        context.email,
+        context.password,
+        undefined,
+        undefined,
+        true,
+        true
+      );
+
+      expect(newApplication.itemManager.notes.length).to.equal(2);
+
+      expect(
+        newApplication.itemManager.notes.find(
+          (n) => n.uuid === firstVersionOfNote.uuid
+        ).text
+      ).to.equal(staleText);
+
+      const conflictedCopy = newApplication.itemManager.notes.find(
+        (n) => n.uuid !== firstVersionOfNote.uuid
+      );
+      expect(conflictedCopy.text).to.equal(serverText);
+      expect(conflictedCopy.duplicate_of).to.equal(firstVersionOfNote.uuid);
+      newApplication.deinit();
+    });
+  });
+});

--- a/test/auth-fringe-cases.test.js
+++ b/test/auth-fringe-cases.test.js
@@ -72,7 +72,8 @@ describe('auth fringe cases', () => {
         context.application
       );
       console.warn(
-        "Expecting errors 'No associated key found for item encrypted with latest protocol version.'"
+        "Expecting errors 'No associated key found for item encrypted with latest protocol version.'",
+        "and 'Unable to find operator for version undefined'"
       );
       await restartedApplication.signIn(
         context.email,
@@ -86,6 +87,7 @@ describe('auth fringe cases', () => {
         note.uuid
       );
       expect(refreshedNote.errorDecrypting).to.equal(false);
+      expect(restartedApplication.itemManager.notes.length).to.equal(1);
       restartedApplication.deinit();
     }).timeout(10000);
   });

--- a/test/keys.test.js
+++ b/test/keys.test.js
@@ -218,14 +218,14 @@ describe('keys', function () {
     expect(typeof rawNotePayload.content).to.equal('string');
   });
 
-  it('should create a new items key upon registration', async function () {
+  it('should keep offline created items key upon registration', async function () {
     expect(this.application.itemManager.itemsKeys().length).to.equal(1);
     const originalItemsKey = this.application.itemManager.itemsKeys()[0];
     await this.application.register(this.email, this.password);
 
     expect(this.application.itemManager.itemsKeys().length).to.equal(1);
     const newestItemsKey = this.application.itemManager.itemsKeys()[0];
-    expect(newestItemsKey.uuid).to.not.equal(originalItemsKey.uuid);
+    expect(newestItemsKey.uuid).to.equal(originalItemsKey.uuid);
   });
 
   it('should use items key for encryption of note', async function () {

--- a/test/lib/factory.js
+++ b/test/lib/factory.js
@@ -87,7 +87,7 @@ export async function setOldVersionPasscode({
     KeyParamsOrigination.PasscodeCreate
   );
   await application.protocolService.setNewRootKeyWrapper(key);
-  await application.rewriteItemsKeys();
+  await application.credentialService.rewriteItemsKeys();
   await application.syncService.sync(syncOptions);
 }
 
@@ -166,8 +166,8 @@ export function createMappedTag(application) {
   );
 }
 
-export async function createSyncedNote(application) {
-  const payload = createNotePayload();
+export async function createSyncedNote(application, title, text) {
+  const payload = createNotePayload(title, text);
   await application.itemManager.emitItemFromPayload(
     payload,
     PayloadSource.LocalChanged
@@ -231,6 +231,13 @@ export async function signOutAndBackIn(application, email, password) {
     email,
     password,
   });
+  return newApplication;
+}
+
+export async function restartApplication(application) {
+  const id = application.identifier;
+  await application.deinit();
+  const newApplication = await createAndInitializeApplication(id);
   return newApplication;
 }
 

--- a/test/preferences.test.js
+++ b/test/preferences.test.js
@@ -68,9 +68,8 @@ describe('preferences', function () {
     await Factory.sleep(0); /** Await next tick */
     expect(callTimes).to.equal(1); /** App start */
     await register.call(this);
-    expect(callTimes).to.equal(2);
     await this.application.setPreference('editorLeft', 300);
-    expect(callTimes).to.equal(3);
+    expect(callTimes).to.equal(2);
   });
 
   it('discards existing preferences when signing in', async function () {

--- a/test/protection.test.js
+++ b/test/protection.test.js
@@ -17,11 +17,10 @@ describe('protections', function () {
   });
 
   it('prompts for password when accessing protected note', async function () {
-    const password = Uuid.GenerateUuidSynchronously();
-
     let challengePrompts = 0;
 
     this.application = await Factory.createApplication(Factory.randomString());
+    const password = Uuid.GenerateUuidSynchronously();
     await this.application.prepareForLaunch({
       receiveChallenge: (challenge) => {
         challengePrompts += 1;

--- a/test/sync_tests/conflicting.test.js
+++ b/test/sync_tests/conflicting.test.js
@@ -807,7 +807,7 @@ describe('online conflict handling', function () {
     );
 
     /**
-     * Retrieve this note from the server by clearing sync toksn
+     * Retrieve this note from the server by clearing sync token
      */
     await this.application.syncService.clearSyncPositionTokens();
     await this.application.syncService.sync({

--- a/test/sync_tests/notes_tags.test.js
+++ b/test/sync_tests/notes_tags.test.js
@@ -102,15 +102,13 @@ describe('notes + tags syncing', async function () {
     // when signing in, all local items are cleared from storage (but kept in memory; to clear desktop logs),
     // then resaved with alternated uuids.
     await this.application.storageService.clearAllPayloads();
-    await this.application.syncService.markAllItemsAsNeedingSync(true);
+    await this.application.syncService.markAllItemsAsNeedingSync();
 
     expect(this.application.itemManager.notes.length).to.equal(1);
     expect(this.application.itemManager.tags.length).to.equal(1);
 
     const note = this.application.itemManager.notes[0];
     const tag = this.application.itemManager.tags[0];
-    expect(note.uuid).to.not.equal(originalNote.uuid);
-    expect(tag.uuid).to.not.equal(originalTag.uuid);
 
     expect(tag.content.references.length).to.equal(1);
     expect(note.content.references.length).to.equal(0);

--- a/test/sync_tests/online.test.js
+++ b/test/sync_tests/online.test.js
@@ -114,13 +114,13 @@ describe('online syncing', function () {
     await Factory.sleep(0.5);
   }).timeout(20000);
 
-  it('marking all items as needing sync with alternation should delete original payload', async function () {
+  it('uuid alternation should delete original payload', async function () {
     this.application = await Factory.signOutApplicationAndReturnNew(
       this.application
     );
     const note = await Factory.createMappedNote(this.application);
     this.expectedItemCount++;
-    await this.application.syncService.markAllItemsAsNeedingSync(true);
+    await this.application.syncService.alternateUuidForItem(note.uuid);
     await this.application.sync(syncOptions);
 
     const notes = this.application.itemManager.notes;
@@ -502,7 +502,7 @@ describe('online syncing', function () {
   it('marking an item dirty then saving to disk should retain that dirty state when restored', async function () {
     const note = await Factory.createMappedNote(this.application);
     this.expectedItemCount++;
-    await this.application.syncService.markAllItemsAsNeedingSync(false);
+    await this.application.syncService.markAllItemsAsNeedingSync();
 
     this.application.itemManager.resetState();
     this.application.payloadManager.resetState();

--- a/test/sync_tests/online.test.js
+++ b/test/sync_tests/online.test.js
@@ -128,7 +128,7 @@ describe('online syncing', function () {
     expect(notes[0].uuid).to.not.equal(note.uuid);
   });
 
-  it('having offline data then signing in should alternate uuid and merge with account', async function () {
+  it('having offline data then signing in should not alternate uuid and merge with account', async function () {
     this.application = await Factory.signOutApplicationAndReturnNew(
       this.application
     );
@@ -144,7 +144,7 @@ describe('online syncing', function () {
     const notes = this.application.itemManager.notes;
     expect(notes.length).to.equal(1);
     /** uuid should have been alternated */
-    expect(notes[0].uuid).to.not.equal(note.uuid);
+    expect(notes[0].uuid).to.equal(note.uuid);
   });
 
   it('server extensions should not be encrypted for sync', async function () {

--- a/test/test.html
+++ b/test/test.html
@@ -69,6 +69,7 @@
   <script type="module" src="sync_tests/online.test.js"></script>
   <script type="module" src="sync_tests/conflicting.test.js"></script>
   <script type="module" src="sync_tests/discordance.test.js"></script>
+  <script type="module" src="auth-fringe-cases.test.js"></script>
   <script type="module" src="auth.test.js"></script>
   <script type="module" src="device_auth.test.js"></script>
   <script type="module" src="storage.test.js"></script>


### PR DESCRIPTION
- creates credential service to centralize account and passcode operations
- fixes issue where if localStorage is wiped by browser improperly (but IndexedDB remains), we perform a corrective sign in that doesn't mark all existing items as dirty before syncing.
- passes items key into transient decryption on sync response
- add traps to avoid duplicating errored payloads