### PR TITLE
feat: add linter rules: varsIgnorePattern, curly/all

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@standardnotes/config",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "engines": {
     "node": ">=14.0.0 <16.0.0"
   },

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@standardnotes/config",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "engines": {
     "node": ">=14.0.0 <16.0.0"
   },

--- a/packages/config/src/.eslintrc
+++ b/packages/config/src/.eslintrc
@@ -17,7 +17,8 @@
         "vars": "all",
         "args": "after-used",
         "ignoreRestSiblings": false,
-        "argsIgnorePattern": "^_"
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_"
       }
     ],
     "@typescript-eslint/no-explicit-any": ["error", { "ignoreRestArgs": true }],
@@ -26,6 +27,7 @@
     "quotes": ["error", "single"],
     "object-curly-spacing": ["error", "always"],
     "indent": ["error", 2],
-    "comma-dangle": ["error", "always-multiline"]
+    "comma-dangle": ["error", "always-multiline"],
+    "curly": ["error", "all"]
   }
 }

--- a/packages/config/src/.prettierrc
+++ b/packages/config/src/.prettierrc
@@ -1,3 +1,4 @@
 {
-  "singleQuote": true
+  "singleQuote": true,
+  "trailingComma": "all"
 }


### PR DESCRIPTION
As discussed with @mobitar and @karolsojko, added rules for ignoring vars (`_name`) and to require curly braces around if/else at all times.