### PR TITLE
Present-value sync

### DIFF
--- a/packages/snjs/lib/index.ts
+++ b/packages/snjs/lib/index.ts
@@ -86,11 +86,10 @@ export {
   SyncQueueStrategy,
 } from './services/sync/sync_service';
 export { SyncResponse } from './services/sync/response';
+export { payloadsByPreparingForServer } from './services/sync/account/operation';
 export { SyncResponseResolver } from '@Services/sync/account/response_resolver';
-export { AccountSyncOperation } from '@Services/sync/account/operation';
 export { SyncOpStatus } from './services/sync/sync_op_status';
 export { SortPayloadsByRecentAndContentPriority } from './services/sync/utils';
-export { SyncUpDownLimit } from './services/sync/account/operation';
 export { SNSessionManager } from './services/api/session_manager';
 export { SNMigrationService } from './services/migration_service';
 export { ButtonType } from './services/alert_service';

--- a/packages/snjs/lib/index.ts
+++ b/packages/snjs/lib/index.ts
@@ -87,6 +87,7 @@ export {
 } from './services/sync/sync_service';
 export { SyncResponse } from './services/sync/response';
 export { SyncResponseResolver } from '@Services/sync/account/response_resolver';
+export { AccountSyncOperation } from '@Services/sync/account/operation';
 export { SyncOpStatus } from './services/sync/sync_op_status';
 export { SortPayloadsByRecentAndContentPriority } from './services/sync/utils';
 export { SyncUpDownLimit } from './services/sync/account/operation';

--- a/packages/snjs/lib/protocol/payloads/deltas/conflict.ts
+++ b/packages/snjs/lib/protocol/payloads/deltas/conflict.ts
@@ -51,8 +51,8 @@ export class ConflictDelta {
       existingConflict &&
       PayloadContentsEqual(existingConflict, this.applyPayload)
     ) {
-      /** Conflict exists and its contents are the same as incoming value, do not make duplicate */
-      return [];
+      // /** Conflict exists and its contents are the same as incoming value, do not make duplicate */
+      strategy = ConflictStrategy.KeepLeft;
     }
     if (strategy === ConflictStrategy.KeepLeft) {
       const updatedAt = greaterOfTwoDates(

--- a/packages/snjs/lib/services/item_manager.ts
+++ b/packages/snjs/lib/services/item_manager.ts
@@ -31,7 +31,6 @@ import { PayloadSource } from './../protocol/payloads/sources';
 import { PurePayload } from './../protocol/payloads/pure_payload';
 import { PayloadManager } from './payload_manager';
 import { ContentType } from '../models/content_types';
-import { ThemeMutator } from '@Lib/models';
 import { ItemCollectionNotesView } from '@Lib/protocol/collection/item_collection_notes_view';
 import { NotesDisplayCriteria } from '@Lib/protocol/collection/notes_display_criteria';
 import { createMutatorForItem } from '@Lib/models/mutator';

--- a/packages/snjs/lib/services/payload_manager.ts
+++ b/packages/snjs/lib/services/payload_manager.ts
@@ -79,8 +79,8 @@ export class PayloadManager extends PureService {
     this.collection = new MutableCollection();
   }
 
-  public find(uuids: UuidString[]) {
-    return this.collection.findAll(uuids);
+  public find(uuids: UuidString[]): PurePayload[] {
+    return this.collection.findAll(uuids) as PurePayload[];
   }
 
   /**

--- a/packages/snjs/lib/services/sync/account/operation.ts
+++ b/packages/snjs/lib/services/sync/account/operation.ts
@@ -1,3 +1,8 @@
+import { EncryptionIntent } from './../../../protocol/intents';
+import { NonEncryptedTypes } from './response_resolver';
+import { SNProtocolService } from './../../protocol_service';
+import { PayloadManager } from './../../payload_manager';
+import { UuidString } from './../../../types';
 import { PurePayload } from '@Payloads/pure_payload';
 import { arrayByDifference, subtractFromArray } from '@Lib/utils';
 import { SyncResponse } from '@Services/sync/response';
@@ -13,41 +18,42 @@ export const SyncUpDownLimit = 150;
 export class AccountSyncOperation {
   public id = Math.random();
 
-  private pendingPayloads: PurePayload[];
+  private pendingUuids: UuidString[];
   private responses: SyncResponse[] = [];
+
+  static UpdownLimit = SyncUpDownLimit;
 
   /**
    * @param payloads   An array of payloads to send to the server
    * @param receiver   A function that receives callback multiple times during the operation
    */
   constructor(
-    private payloads: PurePayload[],
+    private uuids: UuidString[],
     private receiver: ResponseSignalReceiver,
     private lastSyncToken: string,
     private paginationToken: string,
     public checkIntegrity: boolean,
-    private apiService: SNApiService
+    private apiService: SNApiService,
+    private payloadManager: PayloadManager,
+    private protocolService: SNProtocolService
   ) {
-    this.payloads = payloads;
-    this.lastSyncToken = lastSyncToken;
-    this.paginationToken = paginationToken;
-    this.checkIntegrity = checkIntegrity;
-    this.apiService = apiService;
-    this.receiver = receiver;
-    this.pendingPayloads = payloads.slice();
+    this.pendingUuids = uuids.slice();
   }
 
   /**
    * Read the payloads that have been saved, or are currently in flight.
    */
-  get payloadsSavedOrSaving() {
-    return arrayByDifference(this.payloads, this.pendingPayloads);
+  get payloadsSavedOrSaving(): PurePayload[] {
+    return arrayByDifference(
+      this.payloadManager.find(this.uuids),
+      this.payloadManager.find(this.pendingUuids)
+    );
   }
 
-  popPayloads(count: number) {
-    const payloads = this.pendingPayloads.slice(0, count);
-    subtractFromArray(this.pendingPayloads, payloads);
-    return payloads;
+  popPayloads(count: number): PurePayload[] {
+    const uuids = this.pendingUuids.slice(0, count);
+    subtractFromArray(this.pendingUuids, uuids);
+    return this.payloadManager.find(uuids);
   }
 
   async run(): Promise<void> {
@@ -55,7 +61,14 @@ export class AccountSyncOperation {
       completedUploadCount: this.totalUploadCount - this.pendingUploadCount,
       totalUploadCount: this.totalUploadCount,
     });
-    const payloads = this.popPayloads(this.upLimit);
+    const payloads = await this.protocolService.payloadsByEncryptingPayloads(
+      this.popPayloads(this.upLimit),
+      (payload) => {
+        return NonEncryptedTypes.includes(payload.content_type!)
+          ? EncryptionIntent.SyncDecrypted
+          : EncryptionIntent.Sync;
+      }
+    );
     const rawResponse = await this.apiService.sync(
       payloads,
       this.lastSyncToken,
@@ -78,27 +91,27 @@ export class AccountSyncOperation {
     }
   }
 
-  get done() {
-    return this.pendingPayloads.length === 0 && !this.paginationToken;
+  get done(): boolean {
+    return this.pendingUuids.length === 0 && !this.paginationToken;
   }
 
   private get pendingUploadCount() {
-    return this.pendingPayloads.length;
+    return this.pendingUuids.length;
   }
 
   private get totalUploadCount() {
-    return this.payloads.length;
+    return this.uuids.length;
   }
 
   private get upLimit() {
-    return SyncUpDownLimit;
+    return AccountSyncOperation.UpdownLimit;
   }
 
   private get downLimit() {
-    return SyncUpDownLimit;
+    return AccountSyncOperation.UpdownLimit;
   }
 
-  get numberOfItemsInvolved() {
+  get numberOfItemsInvolved(): number {
     let total = 0;
     for (const response of this.responses) {
       total += response.numberOfItemsInvolved;

--- a/test/auth-fringe-cases.test.js
+++ b/test/auth-fringe-cases.test.js
@@ -7,11 +7,6 @@ const expect = chai.expect;
 describe('auth fringe cases', () => {
   const BASE_ITEM_COUNT = ['default items key', 'user prefs'].length;
 
-  const syncOptions = {
-    checkIntegrity: true,
-    awaitAll: true,
-  };
-
   const createContext = async () => {
     const application = await Factory.createInitAppWithRandNamespace();
     return {

--- a/test/sync_tests/conflicting.test.js
+++ b/test/sync_tests/conflicting.test.js
@@ -4,7 +4,7 @@ import * as Factory from '../lib/factory.js';
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 
-describe.only('online conflict handling', function () {
+describe('online conflict handling', function () {
   this.timeout(Factory.TestTimeout);
   const BASE_ITEM_COUNT = 2; /** Default items key, user preferences */
 
@@ -551,7 +551,7 @@ describe.only('online conflict handling', function () {
     /** This number must be greater than the pagination limit per sync request.
      * For example if the limit per request is 150 items sent/received, this number should
      * be something like 160. */
-    const largeItemCount = SyncUpDownLimit + 10;
+    const largeItemCount = this.application.syncService.upDownLimit + 10;
     await Factory.createManyMappedNotes(this.application, largeItemCount);
     /** Upload */
     await this.application.syncService.sync(syncOptions);
@@ -841,7 +841,7 @@ describe.only('online conflict handling', function () {
        */
 
       /** Create bulk data belonging to another account and sync */
-      const largeItemCount = SyncUpDownLimit + 10;
+      const largeItemCount = this.application.syncService.upDownLimit + 10;
       await Factory.createManyMappedNotes(this.application, largeItemCount);
       await this.application.syncService.sync(syncOptions);
       const priorData = this.application.itemManager.items;

--- a/test/sync_tests/conflicting.test.js
+++ b/test/sync_tests/conflicting.test.js
@@ -4,7 +4,7 @@ import * as Factory from '../lib/factory.js';
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 
-describe('online conflict handling', function () {
+describe.only('online conflict handling', function () {
   this.timeout(Factory.TestTimeout);
   const BASE_ITEM_COUNT = 2; /** Default items key, user preferences */
 

--- a/test/sync_tests/online.test.js
+++ b/test/sync_tests/online.test.js
@@ -1038,17 +1038,16 @@ describe('online syncing', function () {
     }
   });
 
-  it.only('retrieved items should have both updated_at and updated_at_timestamps', async function () {
-    this.application.syncService.loggingEnabled = true;
+  it('retrieved items should have both updated_at and updated_at_timestamps', async function () {
     const note = await Factory.createSyncedNote(this.application);
     this.expectedItemCount++;
-    expect(note.created_at_timestamp).to.be.ok;
-    expect(note.created_at).to.be.ok;
-    expect(note.updated_at_timestamp).to.be.ok;
-    expect(note.updated_at).to.be.ok;
+    expect(note.payload.created_at_timestamp).to.be.ok;
+    expect(note.payload.created_at).to.be.ok;
+    expect(note.payload.updated_at_timestamp).to.be.ok;
+    expect(note.payload.updated_at).to.be.ok;
   });
 
-  it.only('server should prioritize updated_at_timestamp over updated_at for sync, if provided', async function () {
+  it('server should prioritize updated_at_timestamp over updated_at for sync, if provided', async function () {
     /**
      * As part of SSRB to SSJS migration, server should prefer to use updated_at_timestamp
      * over updated_at for sync conflict logic. The timestamps are more accurate and support
@@ -1070,9 +1069,8 @@ describe('online syncing', function () {
       },
       dirty: true,
     });
-    await this.application.emitItemFromPayload(modified);
+    await this.application.itemManager.emitItemFromPayload(modified);
     await this.application.sync();
     expect(this.application.itemManager.notes.length).to.equal(1);
-    await this.sharedFinalAssertions();
   });
 });

--- a/test/sync_tests/online.test.js
+++ b/test/sync_tests/online.test.js
@@ -1046,31 +1046,4 @@ describe('online syncing', function () {
     expect(note.payload.updated_at_timestamp).to.be.ok;
     expect(note.payload.updated_at).to.be.ok;
   });
-
-  it('server should prioritize updated_at_timestamp over updated_at for sync, if provided', async function () {
-    /**
-     * As part of SSRB to SSJS migration, server should prefer to use updated_at_timestamp
-     * over updated_at for sync conflict logic. The timestamps are more accurate and support
-     * microsecond precision, versus date objects which only go up to milliseconds.
-     */
-    const note = await Factory.createSyncedNote(this.application);
-    this.expectedItemCount++;
-
-    /**
-     * Create a modified payload that has updated_at set to old value, but updated_at_timestamp
-     * set to new value. Then send to server. If the server conflicts, it means it's incorrectly ignoring
-     * updated_at_timestamp and looking at updated_at.
-     */
-    const modified = CopyPayload(note.payload, {
-      updated_at: new Date(0),
-      content: {
-        ...note.content,
-        title: Math.random(),
-      },
-      dirty: true,
-    });
-    await this.application.itemManager.emitItemFromPayload(modified);
-    await this.application.sync();
-    expect(this.application.itemManager.notes.length).to.equal(1);
-  });
 });

--- a/test/sync_tests/online.test.js
+++ b/test/sync_tests/online.test.js
@@ -155,7 +155,8 @@ describe('online syncing', function () {
         secret: '123',
       },
     });
-    const results = await this.application.syncService.payloadsByPreparingForServer(
+    const results = await payloadsByPreparingForServer(
+      this.application.protocolService,
       [payload]
     );
     const processed = results[0];
@@ -1048,7 +1049,6 @@ describe('online syncing', function () {
   });
 
   it('should use latest value of item when performing second page of sync', async function () {
-    // this.application.syncService.loggingEnabled = true;
     /**
      * If 151 items are set to sync, and the per page limit is 150, then the 151st item
      * will be queued to sync after the first page completes. We want to make sure that
@@ -1058,7 +1058,7 @@ describe('online syncing', function () {
     const noteCount = 3;
     await Factory.createManyMappedNotes(this.application, noteCount);
     this.expectedItemCount += noteCount;
-    AccountSyncOperation.UpdownLimit = noteCount - 1;
+    this.application.syncService.upDownLimit = noteCount - 1;
     const dirtyItems = this.application.syncService.itemsNeedingSync();
     expect(dirtyItems.length).to.equal(noteCount);
     const lastItemUuid = dirtyItems[dirtyItems.length - 1].uuid;

--- a/test/sync_tests/online.test.js
+++ b/test/sync_tests/online.test.js
@@ -1046,4 +1046,50 @@ describe('online syncing', function () {
     expect(note.payload.updated_at_timestamp).to.be.ok;
     expect(note.payload.updated_at).to.be.ok;
   });
+
+  it('should use latest value of item when performing second page of sync', async function () {
+    // this.application.syncService.loggingEnabled = true;
+    /**
+     * If 151 items are set to sync, and the per page limit is 150, then the 151st item
+     * will be queued to sync after the first page completes. We want to make sure that
+     * in the second sync, the latest value of the 151st item is used, and not its value
+     * when it was first marked as dirty
+     */
+    const noteCount = 3;
+    await Factory.createManyMappedNotes(this.application, noteCount);
+    this.expectedItemCount += noteCount;
+    AccountSyncOperation.UpdownLimit = noteCount - 1;
+    const dirtyItems = this.application.syncService.itemsNeedingSync();
+    expect(dirtyItems.length).to.equal(noteCount);
+    const lastItemUuid = dirtyItems[dirtyItems.length - 1].uuid;
+    let syncCount = 0;
+    this.application.addSingleEventObserver(
+      ApplicationEvent.WillSync,
+      async () => {
+        /** Modify the last item. Change the deleted value so that this value
+         * can be easily checked on saved_items response */
+        if (syncCount === 0) {
+          await this.application.itemManager.setItemToBeDeleted(lastItemUuid);
+          this.expectedItemCount--;
+        }
+      }
+    );
+
+    let testDidExcute = false;
+    this.application.syncService.addEventObserver((eventName, data) => {
+      if (eventName === SyncEvent.SingleSyncCompleted) {
+        if (syncCount === 1) {
+          const matchingPayload = data.savedPayloads.find(
+            (p) => p.uuid === lastItemUuid
+          );
+          expect(matchingPayload.deleted).to.equal(true);
+          testDidExcute = true;
+        }
+        syncCount++;
+      }
+    });
+
+    await this.application.sync();
+    expect(testDidExcute).to.equal(true);
+  });
 });

--- a/test/sync_tests/online.test.js
+++ b/test/sync_tests/online.test.js
@@ -1038,12 +1038,41 @@ describe('online syncing', function () {
     }
   });
 
-  it('retrieved items should have both updated_at and updated_at_timestamps', async function () {
+  it.only('retrieved items should have both updated_at and updated_at_timestamps', async function () {
+    this.application.syncService.loggingEnabled = true;
     const note = await Factory.createSyncedNote(this.application);
     this.expectedItemCount++;
-    expect(note.payload.created_at_timestamp).to.be.ok;
-    expect(note.payload.created_at).to.be.ok;
-    expect(note.payload.updated_at_timestamp).to.be.ok;
-    expect(note.payload.updated_at).to.be.ok;
+    expect(note.created_at_timestamp).to.be.ok;
+    expect(note.created_at).to.be.ok;
+    expect(note.updated_at_timestamp).to.be.ok;
+    expect(note.updated_at).to.be.ok;
+  });
+
+  it.only('server should prioritize updated_at_timestamp over updated_at for sync, if provided', async function () {
+    /**
+     * As part of SSRB to SSJS migration, server should prefer to use updated_at_timestamp
+     * over updated_at for sync conflict logic. The timestamps are more accurate and support
+     * microsecond precision, versus date objects which only go up to milliseconds.
+     */
+    const note = await Factory.createSyncedNote(this.application);
+    this.expectedItemCount++;
+
+    /**
+     * Create a modified payload that has updated_at set to old value, but updated_at_timestamp
+     * set to new value. Then send to server. If the server conflicts, it means it's incorrectly ignoring
+     * updated_at_timestamp and looking at updated_at.
+     */
+    const modified = CopyPayload(note.payload, {
+      updated_at: new Date(0),
+      content: {
+        ...note.content,
+        title: Math.random(),
+      },
+      dirty: true,
+    });
+    await this.application.emitItemFromPayload(modified);
+    await this.application.sync();
+    expect(this.application.itemManager.notes.length).to.equal(1);
+    await this.sharedFinalAssertions();
   });
 });


### PR DESCRIPTION
If 151 items are set to sync, and the per page limit is 150, then the 151st item will be queued to sync after the first page completes. We want to make sure that in the second sync, the latest value of the 151st item is used, and not its value when it was first marked as dirty

Previously, if all 151 items were marked as dirty together, then the value of the 151st item would be frozen in time of setting to dirty, and after the first page request, a second page sync request is made using that potentially stale value. In this solution, we always read the present value of an item right before sending it to the server. So we are instead holding in memory the UUIDs of dirty items, rather than a static frozen-in-time representation of the values it had when it was dirtied.