### PR TITLE
feat: add methods for multiple selection

### DIFF
--- a/packages/snjs/lib/application.ts
+++ b/packages/snjs/lib/application.ts
@@ -704,11 +704,11 @@ export class SNApplication {
     return unprotectedNote;
   }
 
-  public async getAuthorizedNotesForProtectedAction(
+  public async authorizeProtectedActionForNotes(
     notes: SNNote[],
     challengeReason: ChallengeReason
   ): Promise<SNNote[]> {
-    return await this.protectionService.getAuthorizedNotesForProtectedAction(
+    return await this.protectionService.authorizeProtectedActionForNotes(
       notes,
       challengeReason
     );

--- a/packages/snjs/lib/application.ts
+++ b/packages/snjs/lib/application.ts
@@ -704,6 +704,28 @@ export class SNApplication {
     return unprotectedNote;
   }
 
+  public async getAuthorizedNotesForProtectedAction(
+    notes: SNNote[],
+    challengeReason: ChallengeReason
+  ): Promise<SNNote[]> {
+    return await this.protectionService.getAuthorizedNotesForProtectedAction(
+      notes,
+      challengeReason
+    );
+  }
+
+  public async protectNotes(notes: SNNote[]): Promise<SNNote[]> {
+    const protectedNotes = await this.protectionService.protectNotes(notes);
+    void this.syncService.sync();
+    return protectedNotes;
+  }
+
+  public async unprotectNotes(notes: SNNote[]): Promise<SNNote[]> {
+    const unprotectedNotes = await this.protectionService.unprotectNotes(notes);
+    void this.syncService.sync();
+    return unprotectedNotes;
+  }
+
   public getItems(contentType: ContentType | ContentType[]): SNItem[] {
     return this.itemManager.getItems(contentType);
   }

--- a/packages/snjs/lib/challenges.ts
+++ b/packages/snjs/lib/challenges.ts
@@ -41,6 +41,7 @@ export enum ChallengeReason {
   DisableBiometrics,
   UnprotectNote,
   SearchProtectedNotesText,
+  SelectProtectedNote,
 }
 
 /** For mobile */
@@ -120,6 +121,8 @@ export class Challenge {
           return ChallengeStrings.UnprotectNote;
         case ChallengeReason.SearchProtectedNotesText:
           return ChallengeStrings.SearchProtectedNotesText;
+        case ChallengeReason.SelectProtectedNote:
+          return ChallengeStrings.SelectProtectedNote;
         case ChallengeReason.Custom:
           return '';
         default:

--- a/packages/snjs/lib/services/api/messages.ts
+++ b/packages/snjs/lib/services/api/messages.ts
@@ -209,6 +209,7 @@ export const ChallengeStrings = {
   DisableBiometrics: 'Authentication is required to disable biometrics',
   UnprotectNote: 'Authentication is required to unprotect a note',
   SearchProtectedNotesText: 'Authentication is required to search protected contents',
+  SelectProtectedNote: 'Authentication is required to select a protected note',
 };
 
 export const PromptTitles = {

--- a/packages/snjs/lib/services/protection_service.ts
+++ b/packages/snjs/lib/services/protection_service.ts
@@ -171,7 +171,7 @@ export class SNProtectionService extends PureService<ProtectionEvent.SessionExpi
     }
   }
 
-  async getAuthorizedNotesForProtectedAction(
+  async authorizeProtectedActionForNotes(
     notes: SNNote[],
     challengeReason: ChallengeReason
   ): Promise<SNNote[]> {
@@ -199,7 +199,7 @@ export class SNProtectionService extends PureService<ProtectionEvent.SessionExpi
   }
 
   async unprotectNotes(notes: SNNote[]): Promise<SNNote[]> {
-    const authorizedNotes = await this.getAuthorizedNotesForProtectedAction(
+    const authorizedNotes = await this.authorizeProtectedActionForNotes(
       notes,
       ChallengeReason.UnprotectNote
     );

--- a/packages/snjs/lib/services/protection_service.ts
+++ b/packages/snjs/lib/services/protection_service.ts
@@ -15,6 +15,7 @@ import { isNullOrUndefined } from '@Lib/utils';
 import { ApplicationStage } from '@Lib/stages';
 import { ItemManager } from './item_manager';
 import { MutationType } from '@Lib/models/core/item';
+import { Uuids } from '@Lib/models/functions';
 
 export enum ProtectionEvent {
   SessionExpiryDateChanged = 'SessionExpiryDateChanged',
@@ -168,6 +169,46 @@ export class SNProtectionService extends PureService<ProtectionEvent.SessionExpi
         mutator.protected = false;
       }) as Promise<SNNote>;
     }
+  }
+
+  async getAuthorizedNotesForProtectedAction(
+    notes: SNNote[],
+    challengeReason: ChallengeReason
+  ): Promise<SNNote[]> {
+    let sessionValidation: Promise<boolean> | undefined;
+    const authorizedNotes = [];
+    for (const note of notes) {
+      const isProtected = note.protected && this.areProtectionsEnabled();
+      if (isProtected && !sessionValidation) {
+        sessionValidation = this.validateOrRenewSession(challengeReason);
+      }
+      if (!isProtected || (await sessionValidation)) {
+        authorizedNotes.push(note);
+      }
+    }
+    return authorizedNotes;
+  }
+
+  protectNotes(notes: SNNote[]): Promise<SNNote[]> {
+    return this.itemManager.changeItems<NoteMutator>(
+      Uuids(notes),
+      (mutator) => {
+        mutator.protected = true;
+      }
+    ) as Promise<SNNote[]>;
+  }
+
+  async unprotectNotes(notes: SNNote[]): Promise<SNNote[]> {
+    const authorizedNotes = await this.getAuthorizedNotesForProtectedAction(
+      notes,
+      ChallengeReason.UnprotectNote
+    );
+    return this.itemManager.changeItems<NoteMutator>(
+      Uuids(authorizedNotes),
+      (mutator) => {
+        mutator.protected = false;
+      }
+    ) as Promise<SNNote[]>;
   }
 
   async authorizeNoteAccess(note: SNNote): Promise<boolean> {

--- a/packages/snjs/package.json
+++ b/packages/snjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@standardnotes/snjs",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "engines": {
     "node": ">=14.0.0 <16.0.0"
   },

--- a/test/protection.test.js
+++ b/test/protection.test.js
@@ -406,7 +406,7 @@ describe('protections', function () {
     });
   });
 
-  describe('getAuthorizedNotesForProtectedAction', async function () {
+  describe('authorizeProtectedActionForNotes', async function () {
     it('prompts for password once with the right challenge reason when one or more notes are protected', async function () {
       let challengePrompts = 0;
       this.application = await Factory.createApplication(Factory.randomString());
@@ -447,7 +447,7 @@ describe('protections', function () {
       notes[0] = await this.application.protectNote(notes[0]);
       notes[1] = await this.application.protectNote(notes[1]);
 
-      expect(await this.application.getAuthorizedNotesForProtectedAction(
+      expect(await this.application.authorizeProtectedActionForNotes(
         notes,
         ChallengeReason.SelectProtectedNote
       )).lengthOf(NOTE_COUNT);
@@ -489,7 +489,7 @@ describe('protections', function () {
       notes[0] = await this.application.protectNote(notes[0]);
       notes[1] = await this.application.protectNote(notes[1]);
 
-      expect(await this.application.getAuthorizedNotesForProtectedAction(
+      expect(await this.application.authorizeProtectedActionForNotes(
         notes,
         ChallengeReason.SelectProtectedNote
       )).lengthOf(NOTE_COUNT);
@@ -515,7 +515,7 @@ describe('protections', function () {
       notes[0] = await this.application.protectNote(notes[0]);
       notes[1] = await this.application.protectNote(notes[1]);
 
-      expect(await this.application.getAuthorizedNotesForProtectedAction(
+      expect(await this.application.authorizeProtectedActionForNotes(
         notes,
         ChallengeReason.SelectProtectedNote
       )).lengthOf(1);


### PR DESCRIPTION
- Extracted some methods needed for multiple selection logic: getAuthorizedNotesForProtectedAction (not sure about the right naming) so that we only prompt for authentication challenge once and authorize a protected action on a batch of notes, and protectNotes and unprotectNotes to protect/unprotect in batch.
- Added SelectProtectedNote challenge reason and its corresponding text.