### PR TITLE
feat: use regex and add note parameter for searchTags

### DIFF
--- a/packages/snjs/lib/application.ts
+++ b/packages/snjs/lib/application.ts
@@ -773,6 +773,12 @@ export class SNApplication {
     return this.itemManager.findTagByTitle(title);
   }
 
+  /**
+   * Finds tags with title or component starting with a search query and (optionally) not associated with a note
+   * @param searchQuery - The query string to match
+   * @param note - The note whose tags should be omitted from results
+   * @returns Array containing tags matching search query and not associated with note
+   */
   public searchTags(searchQuery: string, note?: SNNote): SNTag[] {
     return this.itemManager.searchTags(searchQuery, note);
   }

--- a/packages/snjs/lib/application.ts
+++ b/packages/snjs/lib/application.ts
@@ -773,8 +773,8 @@ export class SNApplication {
     return this.itemManager.findTagByTitle(title);
   }
 
-  public searchTags(searchQuery: string): SNTag[] {
-    return this.itemManager.searchTags(searchQuery);
+  public searchTags(searchQuery: string, note?: SNNote): SNTag[] {
+    return this.itemManager.searchTags(searchQuery, note);
   }
 
   public async findOrCreateTag(title: string): Promise<SNTag> {

--- a/packages/snjs/lib/services/item_manager.ts
+++ b/packages/snjs/lib/services/item_manager.ts
@@ -724,7 +724,10 @@ export class ItemManager extends PureService {
   }
 
   /**
-   * Finds tags with titles starting with a search query
+   * Finds tags with title or component starting with a search query and (optionally) not associated with a note
+   * @param searchQuery - The query string to match
+   * @param note - The note whose tags should be omitted from results
+   * @returns Array containing tags matching search query and not associated with note
    */
   public searchTags(searchQuery: string, note?: SNNote): SNTag[] {
     const delimiter = '.';

--- a/packages/snjs/package.json
+++ b/packages/snjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@standardnotes/snjs",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "engines": {
     "node": ">=14.0.0 <16.0.0"
   },

--- a/test/item_manager.test.js
+++ b/test/item_manager.test.js
@@ -523,6 +523,13 @@ describe('item manager', function () {
       expect(results).lengthOf(1);
       expect(results[0].title).to.equal(tag.title);
     });
+    it('should return tags with matching query including delimiter', async function() {
+      const tag = await this.itemManager.findOrCreateTagByTitle('parent.child');
+
+      const results = this.itemManager.searchTags('parent.chi');
+      expect(results).lengthOf(1);
+      expect(results[0].title).to.equal(tag.title);
+    });
     it('should return tags in natural order', async function() {
       const firstTag = await this.itemManager.findOrCreateTagByTitle('tag 100');
       const secondTag = await this.itemManager.findOrCreateTagByTitle('tag 2');
@@ -536,5 +543,18 @@ describe('item manager', function () {
       expect(results[2].title).to.equal(fourthTag.title);
       expect(results[3].title).to.equal(thirdTag.title);
     });
+    it('should not return tags associated with note', async function () {
+      const firstTag = await this.itemManager.findOrCreateTagByTitle('tag one');
+      const secondTag = await this.itemManager.findOrCreateTagByTitle('tag two');
+
+      const note = await this.createNote();
+      await this.itemManager.changeItem(firstTag.uuid, (mutator) => {
+        mutator.addItemAsRelationship(note);
+      });
+
+      const results = this.itemManager.searchTags('tag', note);
+      expect(results).lengthOf(1);
+      expect(results[0].title).to.equal(secondTag.title);
+    })
   })
 });


### PR DESCRIPTION
- Use regex for query matching, so that a result will be returned if either the title starts with the query, or the query is present after a delimiter. This means if we have a tag with a "parent.child.grandchild" title, searching for "parent.child" and "child.grandchild" will both return it as a result.
- Add optional note parameter to searchTags method, so that when this parameter is passed, tags associated with that note will not be returned in results. This will allow us to show only tags not currently added to the note in the search dropdown.