### PR TITLE
fix: use created_at for unsynced session history entries

### DIFF
--- a/packages/snjs/lib/protocol/payloads/pure_payload.ts
+++ b/packages/snjs/lib/protocol/payloads/pure_payload.ts
@@ -39,7 +39,7 @@ export class PurePayload {
   readonly created_at?: Date;
   /** updated_at is set by the server only, and not the client.
    * For user modification date, see userModifiedAt */
-  readonly updated_at?: Date;
+  readonly updated_at: Date;
   readonly created_at_timestamp?: number;
   readonly updated_at_timestamp?: number;
   readonly dirtiedDate?: Date;
@@ -94,7 +94,7 @@ export class PurePayload {
     /** Fallback to initializing with now date */
     this.created_at = new Date(rawPayload.created_at || new Date());
     /** Fallback to initializing with 0 epoch date */
-    this.updated_at = new Date(rawPayload.updated_at || new Date(0));
+    this.updated_at = new Date(rawPayload.updated_at || 0);
     this.created_at_timestamp = rawPayload.created_at_timestamp;
     this.updated_at_timestamp = rawPayload.updated_at_timestamp;
     if (rawPayload.dirtiedDate) {
@@ -212,7 +212,7 @@ export class PurePayload {
     return this.deleted && !this.dirty;
   }
 
-  public get serverUpdatedAt(): Date | undefined {
+  public get serverUpdatedAt(): Date {
     return this.updated_at;
   }
 }

--- a/packages/snjs/lib/services/history/entries/history_entry.ts
+++ b/packages/snjs/lib/services/history/entries/history_entry.ts
@@ -12,10 +12,7 @@ export class HistoryEntry {
   protected readonly hasPreviousEntry: boolean;
 
   constructor(payload: SurePayload, previousEntry?: HistoryEntry) {
-    const updated_at = payload.serverUpdatedAt ?? new Date();
-    this.payload = CopyPayload(payload, {
-      updated_at: updated_at,
-    }) as SurePayload;
+    this.payload = CopyPayload(payload) as SurePayload;
     this.previousEntry = previousEntry;
     this.hasPreviousEntry = !isNullOrUndefined(previousEntry);
     /** We'll try to compute the delta based on an assumed

--- a/packages/snjs/lib/services/history/entries/note_history_entry.ts
+++ b/packages/snjs/lib/services/history/entries/note_history_entry.ts
@@ -3,7 +3,11 @@ import { HistoryEntry } from '@Services/history/entries/history_entry';
 
 export class NoteHistoryEntry extends HistoryEntry {
   previewTitle(): string {
-    return this.payload.updated_at!.toLocaleString();
+    if (this.payload.updated_at.getTime() > 0) {
+      return this.payload.updated_at.toLocaleString();
+    } else {
+      return this.payload.created_at!.toLocaleString();
+    }
   }
 
   previewSubTitle(): string {

--- a/packages/snjs/package.json
+++ b/packages/snjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@standardnotes/snjs",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "engines": {
     "node": ">=14.0.0 <16.0.0"
   },

--- a/packages/snjs/package.json
+++ b/packages/snjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@standardnotes/snjs",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "engines": {
     "node": ">=14.0.0 <16.0.0"
   },

--- a/test/history.test.js
+++ b/test/history.test.js
@@ -333,6 +333,28 @@ describe('history manager', () => {
         latestRevision.itemFromPayload().userModifiedDate
       ).to.be.greaterThan(initialRevision.itemFromPayload().userModifiedDate);
     }).timeout(10000);
+
+    it('unsynced entries should use payload created_at for preview titles', async function () {
+      const payload = Factory.createNotePayload();
+      await this.application.itemManager.emitItemFromPayload(
+        payload,
+        PayloadSource.LocalChanged
+      );
+      const item = this.application.findItem(payload.uuid);
+      await this.application.changeAndSaveItem(
+        item.uuid,
+        (mutator) => {
+          mutator.title = Math.random();
+        },
+        undefined,
+        undefined,
+        syncOptions
+      );
+      const historyItem = this.historyManager.sessionHistoryForItem(item)[0];
+      expect(historyItem.previewTitle()).to.equal(
+        historyItem.payload.created_at.toLocaleString()
+      );
+    });
   });
 
   describe('remote', async function () {


### PR DESCRIPTION
See https://github.com/standardnotes/mobile/issues/432