### PR TITLE
feat: natural sort tags and notes

### DIFF
--- a/packages/snjs/lib/application.ts
+++ b/packages/snjs/lib/application.ts
@@ -783,6 +783,15 @@ export class SNApplication {
     return this.itemManager.searchTags(searchQuery, note);
   }
 
+  /**
+   * Get tags for a note sorted in natural order
+   * @param note - The note whose tags will be returned
+   * @returns Array containing tags associated with a note
+   */
+  public getSortedTagsForNote(note: SNNote): SNTag[] {
+    return this.itemManager.getSortedTagsForNote(note);
+  }
+
   public async findOrCreateTag(title: string): Promise<SNTag> {
     return this.itemManager.findOrCreateTagByTitle(title);
   }

--- a/packages/snjs/lib/index.ts
+++ b/packages/snjs/lib/index.ts
@@ -120,6 +120,7 @@ export {
   isNullOrUndefined,
   isSameDay,
   jsonParseEmbeddedKeys,
+  naturalSort,
   omitInPlace,
   omitUndefinedCopy,
   removeFromArray,

--- a/packages/snjs/lib/protocol/collection/item_collection.ts
+++ b/packages/snjs/lib/protocol/collection/item_collection.ts
@@ -225,7 +225,7 @@ export class ItemCollection extends MutableCollection<SNItem> {
         vector *= -1;
       }
       if (sortBy.key === CollectionSort.Title) {
-        return vector * aValue.localeCompare(bValue);
+        return vector * aValue.localeCompare(bValue, 'en', { numeric: true });
       } else if (aValue > bValue) {
         return -1 * vector;
       } else if (aValue < bValue) {

--- a/packages/snjs/lib/services/item_manager.ts
+++ b/packages/snjs/lib/services/item_manager.ts
@@ -51,11 +51,6 @@ type Observer = {
   callback: ObserverCallback;
 };
 
-const collator =
-  typeof Intl !== 'undefined'
-    ? new Intl.Collator('en', { numeric: true })
-    : undefined;
-
 /**
  * The item manager is backed by the Payload Manager. Think of the item manager as a
  * more user-friendly or item-specific interface to creating and updating data.
@@ -746,6 +741,19 @@ export class ItemManager extends PureService {
       'title'
     );
   }
+
+  /**
+   * Get tags for a note sorted in natural order
+   * @param note - The note whose tags will be returned
+   * @returns Array containing tags associated with a note
+   */
+  public getSortedTagsForNote(note: SNNote): SNTag[] {
+    return naturalSort(
+      this.itemsReferencingItem(note.uuid).filter((ref) => {
+        return ref?.content_type === ContentType.Tag;
+      }) as SNTag[],
+      'title'
+    );
   }
 
   /**

--- a/packages/snjs/lib/services/item_manager.ts
+++ b/packages/snjs/lib/services/item_manager.ts
@@ -18,7 +18,7 @@ import { FillItemContent, Uuids } from '@Models/functions';
 import { PureService } from '@Lib/services/pure_service';
 import { ComponentMutator } from './../models/app/component';
 import { SNComponent } from '@Models/app/component';
-import { isString, removeFromArray, searchArray } from '@Lib/utils';
+import { isString, naturalSort, removeFromArray, searchArray } from '@Lib/utils';
 import { CreateMaxPayloadFromAnyObject } from '@Payloads/generator';
 import {
   PayloadContent,
@@ -731,24 +731,21 @@ export class ItemManager extends PureService {
    */
   public searchTags(searchQuery: string, note?: SNNote): SNTag[] {
     const delimiter = '.';
-    const lowerCaseQuery = searchQuery.toLowerCase();
-    return this.tags
-      .filter((tag) => {
-        const lowerCaseTitle = tag.title.toLowerCase();
+    return naturalSort(
+      this.tags.filter((tag) => {
         const regex = new RegExp(
-          `^${lowerCaseQuery}|${delimiter}${lowerCaseQuery}`
+          `^${searchQuery}|${delimiter}${searchQuery}`,
+          'i'
         );
-        const matchesQuery = regex.test(lowerCaseTitle);
+        const matchesQuery = regex.test(tag.title);
         const tagInNote = note
           ? this.itemsReferencingItem(note.uuid).some((item) => item === tag)
           : false;
         return matchesQuery && !tagInNote;
-      })
-      .sort(
-        collator
-          ? (a, b) => collator.compare(a.title, b.title)
-          : (a, b) => a.title.localeCompare(b.title, 'en', { numeric: true })
-      );
+      }),
+      'title'
+    );
+  }
   }
 
   /**

--- a/packages/snjs/lib/services/item_manager.ts
+++ b/packages/snjs/lib/services/item_manager.ts
@@ -739,7 +739,7 @@ export class ItemManager extends PureService {
         );
         const matchesQuery = regex.test(tag.title);
         const tagInNote = note
-          ? this.itemsReferencingItem(note.uuid).some((item) => item === tag)
+          ? this.itemsReferencingItem(note.uuid).some((item) => item?.uuid === tag.uuid)
           : false;
         return matchesQuery && !tagInNote;
       }),

--- a/packages/snjs/lib/utils.ts
+++ b/packages/snjs/lib/utils.ts
@@ -553,19 +553,25 @@ export function isSameDay(dateA: Date, dateB: Date) {
    * @param direction - The sorting direction, either ascending (default) or descending
    * @returns Array of objects sorted in natural order
    */
-export function naturalSort(items: any[], property: string, direction: 'asc' | 'desc' = 'asc'): any[] {
+export function naturalSort<T extends AnyRecord>(
+  items: T[],
+  property: keyof T,
+  direction: 'asc' | 'desc' = 'asc'
+): T[] {
   switch (direction) {
     case 'asc':
       return [...items].sort(
         collator
           ? (a, b) => collator.compare(a[property], b[property])
-          : (a, b) => a[property].localeCompare(b[property], 'en', { numeric: true })
+          : (a, b) =>
+              a[property].localeCompare(b[property], 'en', { numeric: true })
       );
     case 'desc':
       return [...items].sort(
         collator
           ? (a, b) => collator.compare(b[property], a[property])
-          : (a, b) => b[property].localeCompare(a[property], 'en', { numeric: true })
+          : (a, b) =>
+              b[property].localeCompare(a[property], 'en', { numeric: true })
       );
   }
 }

--- a/packages/snjs/lib/utils.ts
+++ b/packages/snjs/lib/utils.ts
@@ -6,6 +6,11 @@ import uniqWith from 'lodash/uniqWith';
 import uniq from 'lodash/uniq';
 import { AnyRecord } from './types';
 
+const collator =
+  typeof Intl !== 'undefined'
+    ? new Intl.Collator('en', { numeric: true })
+    : undefined;
+
 export function getGlobalScope(): Window | unknown | null {
   return typeof window !== 'undefined'
     ? window
@@ -539,4 +544,28 @@ export function isSameDay(dateA: Date, dateB: Date) {
     dateA.getMonth() === dateB.getMonth() &&
     dateA.getDate() === dateB.getDate()
   );
+}
+
+ /**
+   * Sorts an array of objects in natural order
+   * @param items - The array of objects to sort
+   * @param property - The objects' property to sort by
+   * @param direction - The sorting direction, either ascending (default) or descending
+   * @returns Array of objects sorted in natural order
+   */
+export function naturalSort(items: any[], property: string, direction: 'asc' | 'desc' = 'asc'): any[] {
+  switch (direction) {
+    case 'asc':
+      return [...items].sort(
+        collator
+          ? (a, b) => collator.compare(a[property], b[property])
+          : (a, b) => a[property].localeCompare(b[property], 'en', { numeric: true })
+      );
+    case 'desc':
+      return [...items].sort(
+        collator
+          ? (a, b) => collator.compare(b[property], a[property])
+          : (a, b) => b[property].localeCompare(a[property], 'en', { numeric: true })
+      );
+  }
 }

--- a/packages/snjs/package.json
+++ b/packages/snjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@standardnotes/snjs",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "engines": {
     "node": ">=14.0.0 <16.0.0"
   },

--- a/test/item_manager.test.js
+++ b/test/item_manager.test.js
@@ -556,5 +556,31 @@ describe('item manager', function () {
       expect(results).lengthOf(1);
       expect(results[0].title).to.equal(secondTag.title);
     })
+  });
+
+  describe('getSortedTagsForNote', async function () {
+    it('should return tags associated with a note in natural order', async function () {
+      const tags = [
+        await this.itemManager.findOrCreateTagByTitle('tag 100'),
+        await this.itemManager.findOrCreateTagByTitle('tag 2'),
+        await this.itemManager.findOrCreateTagByTitle('tag b'),
+        await this.itemManager.findOrCreateTagByTitle('tag a'),
+      ];
+
+      const note = await this.createNote();
+
+      tags.map(async tag => {
+        await this.itemManager.changeItem(tag.uuid, (mutator) => {
+          mutator.addItemAsRelationship(note);
+        });
+      });
+
+      const results = this.itemManager.getSortedTagsForNote(note);
+      expect(results).lengthOf(tags.length);
+      expect(results[0].title).to.equal(tags[1].title);
+      expect(results[1].title).to.equal(tags[0].title);
+      expect(results[2].title).to.equal(tags[3].title);
+      expect(results[3].title).to.equal(tags[2].title);
+    })
   })
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -189,4 +189,45 @@ describe('utils', () => {
       expect(result).to.equal(false);
     });
   });
+
+  describe('naturalSort', () => {
+    let items;
+    beforeEach(() => {
+      items = [
+        {
+          someProperty: 'a',
+        },
+        {
+          someProperty: 'b',
+        },
+        {
+          someProperty: '2',
+        },
+        {
+          someProperty: 'A',
+        },
+        {
+          someProperty: '1',
+        }
+      ]
+    });
+    it('sorts elements in natural order in ascending direction by default', () => {
+      const result = naturalSort(items, 'someProperty');
+      expect(result).lengthOf(items.length);
+      expect(result[0]).to.equal(items[4]);
+      expect(result[1]).to.equal(items[2]);
+      expect(result[2]).to.equal(items[0]);
+      expect(result[3]).to.equal(items[3]);
+      expect(result[4]).to.equal(items[1]);
+    });
+    it('sorts elements in natural order in descending direction', () => {
+      const result = naturalSort(items, 'someProperty', 'desc');
+      expect(result).lengthOf(items.length);
+      expect(result[0]).to.equal(items[1]);
+      expect(result[1]).to.equal(items[3]);
+      expect(result[2]).to.equal(items[0]);
+      expect(result[3]).to.equal(items[2]);
+      expect(result[4]).to.equal(items[4]);
+    });
+  })
 });


### PR DESCRIPTION
- Added naturalSort util which uses Intl.Collator (if available), and if not, locale.compare.
- Modified searchTags to use naturalSort util, to use the case-insensitive flag in the regex instead of transforming strings using toLowerCase(), and to compare tag UUID instead of the entire tag when filtering out tags already in a note.
- Added getSortedTagsForNote method, which returns tags for a note in natural order. This will be used to display tags in the current note, now that we will no longer show them joined in a string.
- Added { numeric: true } parameter to item sorting by title, so notes ordered by title are sorted in natural order 