### PR TITLE
feat: add getParentTags method

### DIFF
--- a/packages/snjs/lib/application.ts
+++ b/packages/snjs/lib/application.ts
@@ -784,6 +784,15 @@ export class SNApplication {
   }
 
   /**
+   * Returns all parents for a tag
+   * @param tag - The tag for which parents need to be found
+   * @returns Array containing all parent tags
+   */
+  public getParentTags(tag: SNTag): SNTag[] {
+    return this.itemManager.getParentTags(tag);
+  }
+
+  /**
    * Get tags for a note sorted in natural order
    * @param note - The note whose tags will be returned
    * @returns Array containing tags associated with a note

--- a/packages/snjs/lib/services/item_manager.ts
+++ b/packages/snjs/lib/services/item_manager.ts
@@ -743,6 +743,23 @@ export class ItemManager extends PureService {
   }
 
   /**
+   * Returns all parents for a tag
+   * @param tag - The tag for which parents need to be found
+   * @returns Array containing all parent tags
+   */
+  public getParentTags(tag: SNTag): SNTag[] {
+    const delimiter = '.';
+    const tagComponents = tag.title.split(delimiter);
+    const childTagTitle = tagComponents[tagComponents.length - 1];
+    return this.tags.filter((t) => {
+      const regex = new RegExp(
+        `${delimiter}${childTagTitle}$`
+      );
+      return regex.test(t.title);
+    });
+  }
+
+  /**
    * Get tags for a note sorted in natural order
    * @param note - The note whose tags will be returned
    * @returns Array containing tags associated with a note

--- a/test/item_manager.test.js
+++ b/test/item_manager.test.js
@@ -582,5 +582,21 @@ describe('item manager', function () {
       expect(results[2].title).to.equal(tags[3].title);
       expect(results[3].title).to.equal(tags[2].title);
     })
+  });
+
+  describe('getParentTags', async function () {
+    it('should return parent tags for a tag', async function () {
+      const parentTags = [
+        await this.itemManager.findOrCreateTagByTitle('parent.child.grandchild'),
+        await this.itemManager.findOrCreateTagByTitle('child.grandchild'),
+      ];
+      const grandchildTag = await this.itemManager.findOrCreateTagByTitle('grandchild');
+      await this.itemManager.findOrCreateTagByTitle('some other tag');
+
+      const results = this.itemManager.getParentTags(grandchildTag);
+      expect(results).lengthOf(parentTags.length);
+      expect(results).to.contain(parentTags[0]);
+      expect(results).to.contain(parentTags[1]);
+    })
   })
 });


### PR DESCRIPTION
Added getParentTags method which returns all parents for a specific tag. This will be used for adding all parents on top of a tag when clicking on it on a note.