### PR TITLE
feat: add alternative host and switch sign out to API v1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       - snjs
 
   api-gateway:
-    image: standardnotes/api-gateway:1.14.0
+    image: standardnotes/api-gateway:1.15.4
     depends_on:
       - syncing-server-js
       - auth

--- a/packages/snjs/lib/application.ts
+++ b/packages/snjs/lib/application.ts
@@ -857,10 +857,7 @@ export class SNApplication {
     return this.apiService.getHost();
   }
 
-  /**
-   * Set the alternative server's URL
-   */
-   public async setAlternativeHost(alternativeHost: string): Promise<void> {
+  public async setAlternativeHost(alternativeHost: string): Promise<void> {
     return this.apiService.setAlternativeHost(alternativeHost);
   }
 

--- a/packages/snjs/lib/application.ts
+++ b/packages/snjs/lib/application.ts
@@ -176,6 +176,7 @@ export class SNApplication {
    * and 'with' is the custom subclass to use.
    * @param skipClasses An array of classes to skip making services for.
    * @param defaultHost Default host to use in ApiService.
+   * @param alternativeHost alternative host used for upgrading API versions in ApiService.
    */
   constructor(
     public environment: Environment,
@@ -185,7 +186,8 @@ export class SNApplication {
     public alertService: SNAlertService,
     public identifier: ApplicationIdentifier,
     private swapClasses: { swap: any; with: any }[],
-    private defaultHost: string
+    private defaultHost: string,
+    private alternativeHost: string
   ) {
     if (!SNLog.onLog) {
       throw Error('SNLog.onLog must be set.');
@@ -222,6 +224,9 @@ export class SNApplication {
     }
     if (!defaultHost) {
       throw Error('defaultHost must be supplied when creating an application.');
+    }
+    if (!alternativeHost) {
+      throw Error('alternativeHost must be supplied when creating an application.');
     }
     this.constructServices();
   }
@@ -850,6 +855,17 @@ export class SNApplication {
 
   public getHost(): string | undefined {
     return this.apiService.getHost();
+  }
+
+  /**
+   * Set the alternative server's URL
+   */
+   public async setAlternativeHost(alternativeHost: string): Promise<void> {
+    return this.apiService.setAlternativeHost(alternativeHost);
+  }
+
+  public getAlternativeHost(): string | undefined {
+    return this.apiService.getAlternativeHost();
   }
 
   public getUser(): User | undefined {
@@ -1496,7 +1512,8 @@ export class SNApplication {
       this.httpService,
       this.storageService,
       this.permissionsService,
-      this.defaultHost
+      this.defaultHost,
+      this.alternativeHost
     );
     this.services.push(this.apiService);
   }

--- a/packages/snjs/lib/application.ts
+++ b/packages/snjs/lib/application.ts
@@ -176,7 +176,7 @@ export class SNApplication {
    * and 'with' is the custom subclass to use.
    * @param skipClasses An array of classes to skip making services for.
    * @param defaultHost Default host to use in ApiService.
-   * @param alternativeHost alternative host used for upgrading API versions in ApiService.
+   * @param nextVersionHost next version host used for upgrading API versions in ApiService.
    */
   constructor(
     public environment: Environment,
@@ -187,7 +187,7 @@ export class SNApplication {
     public identifier: ApplicationIdentifier,
     private swapClasses: { swap: any; with: any }[],
     private defaultHost: string,
-    private alternativeHost: string
+    private nextVersionHost: string
   ) {
     if (!SNLog.onLog) {
       throw Error('SNLog.onLog must be set.');
@@ -225,8 +225,8 @@ export class SNApplication {
     if (!defaultHost) {
       throw Error('defaultHost must be supplied when creating an application.');
     }
-    if (!alternativeHost) {
-      throw Error('alternativeHost must be supplied when creating an application.');
+    if (!nextVersionHost) {
+      throw Error('nextVersionHost must be supplied when creating an application.');
     }
     this.constructServices();
   }
@@ -857,12 +857,12 @@ export class SNApplication {
     return this.apiService.getHost();
   }
 
-  public async setAlternativeHost(alternativeHost: string): Promise<void> {
-    return this.apiService.setAlternativeHost(alternativeHost);
+  public async setNextVersionHost(nextVersionHost: string): Promise<void> {
+    return this.apiService.setNextVersionHost(nextVersionHost);
   }
 
-  public getAlternativeHost(): string | undefined {
-    return this.apiService.getAlternativeHost();
+  public getNextVersionHost(): string | undefined {
+    return this.apiService.getNextVersionHost();
   }
 
   public getUser(): User | undefined {
@@ -1510,7 +1510,7 @@ export class SNApplication {
       this.storageService,
       this.permissionsService,
       this.defaultHost,
-      this.alternativeHost
+      this.nextVersionHost
     );
     this.services.push(this.apiService);
   }

--- a/packages/snjs/lib/services/api/api_service.ts
+++ b/packages/snjs/lib/services/api/api_service.ts
@@ -146,8 +146,8 @@ export class SNApiService extends PureService {
       storedAlternativeValue ||
       this.alternativeHost ||
       (window as {
-        _default_alternative_sync_server?: string;
-      })._default_alternative_sync_server;
+        _alternative_sync_server?: string;
+      })._alternative_sync_server;
   }
 
   public async setHost(host: string): Promise<void> {

--- a/packages/snjs/lib/services/api/api_service.ts
+++ b/packages/snjs/lib/services/api/api_service.ts
@@ -37,18 +37,19 @@ type PathNames = {
   keyParams: string;
   register: string;
   signIn: string;
-  changePassword: string;
+  changePassword: string | ((userUuid: string) => string);
   sync: string;
   signOut: string;
   refreshSession: string;
   sessions: string;
-  session: string;
+  session: string | ((sessionUuid: string) => string);
   itemRevisions: (itemId: string) => string;
   itemRevision: (itemId: string, revisionId: string) => string;
 };
 
 const Paths: {
   v0: PathNames;
+  v1: PathNames;
 } = {
   v0: {
     keyParams: '/auth/params',
@@ -64,6 +65,20 @@ const Paths: {
     itemRevision: (itemId: string, revisionId: string) =>
       `/items/${itemId}/revisions/${revisionId}`,
   },
+  v1: {
+    keyParams: '/v1/login-params',
+    register: '/v1/users',
+    signIn: '/v1/login',
+    changePassword: (userUuid: string) => `/v1/users/${userUuid}/password`,
+    sync: '/v1/items',
+    signOut: '/v1/logout',
+    refreshSession: '/v1/sessions/refresh',
+    sessions: '/v1/sessions',
+    session: (sessionUuid: string) => `/v1/sessions/${sessionUuid}`,
+    itemRevisions: (itemUuid: string) => `/v1/items/${itemUuid}/revisions`,
+    itemRevision: (itemUuid: string, revisionUuid: string) =>
+      `/v1/items/${itemUuid}/revisions/${revisionUuid}`,
+  }
 };
 
 /** Legacy api version field to be specified in params when calling v0 APIs. */
@@ -85,7 +100,8 @@ export class SNApiService extends PureService {
     private httpService: SNHttpService,
     private storageService: SNStorageService,
     private permissionsService: SNPermissionsService,
-    private host: string
+    private host: string,
+    private alternativeHost: string
   ) {
     super();
   }
@@ -121,6 +137,17 @@ export class SNApiService extends PureService {
       (window as {
         _default_sync_server?: string;
       })._default_sync_server;
+
+    const storedAlternativeValue = await this.storageService.getValue(
+      StorageKey.AlternativeServerHost
+    );
+
+    this.alternativeHost =
+      storedAlternativeValue ||
+      this.alternativeHost ||
+      (window as {
+        _default_alternative_sync_server?: string;
+      })._default_alternative_sync_server;
   }
 
   public async setHost(host: string): Promise<void> {
@@ -130,6 +157,15 @@ export class SNApiService extends PureService {
 
   public getHost(): string | undefined {
     return this.host;
+  }
+
+  public async setAlternativeHost(alternativeHost: string): Promise<void> {
+    this.alternativeHost = alternativeHost;
+    await this.storageService.setValue(StorageKey.AlternativeServerHost, alternativeHost);
+  }
+
+  public getAlternativeHost(): string | undefined {
+    return this.alternativeHost;
   }
 
   public async setSession(session: Session, persist = true): Promise<void> {
@@ -297,7 +333,7 @@ export class SNApiService extends PureService {
   }
 
   signOut(): Promise<SignOutResponse> {
-    const url = joinPaths(this.host, Paths.v0.signOut);
+    const url = joinPaths(this.alternativeHost, Paths.v1.signOut);
     return this.httpService
       .postAbsolute(url, undefined, this.session!.authorizationValue)
       .catch((errorResponse) => {
@@ -320,7 +356,7 @@ export class SNApiService extends PureService {
       return preprocessingError;
     }
     this.changing = true;
-    const url = joinPaths(this.host, Paths.v0.changePassword);
+    const url = joinPaths(this.host, <string> Paths.v0.changePassword);
     const params = this.params({
       current_password: currentServerPassword,
       new_password: newServerPassword,
@@ -474,7 +510,7 @@ export class SNApiService extends PureService {
     if (preprocessingError) {
       return preprocessingError;
     }
-    const url = joinPaths(this.host, Paths.v0.session);
+    const url = joinPaths(this.host, <string> Paths.v0.session);
     const response:
       | RevisionListResponse
       | HttpResponse = await this.httpService

--- a/packages/snjs/lib/services/api/api_service.ts
+++ b/packages/snjs/lib/services/api/api_service.ts
@@ -101,7 +101,7 @@ export class SNApiService extends PureService {
     private storageService: SNStorageService,
     private permissionsService: SNPermissionsService,
     private host: string,
-    private alternativeHost: string
+    private nextVersionHost: string
   ) {
     super();
   }
@@ -138,16 +138,16 @@ export class SNApiService extends PureService {
         _default_sync_server?: string;
       })._default_sync_server;
 
-    const storedAlternativeValue = await this.storageService.getValue(
-      StorageKey.AlternativeServerHost
+    const storedNextVersionValue = await this.storageService.getValue(
+      StorageKey.NextVersionServerHost
     );
 
-    this.alternativeHost =
-      storedAlternativeValue ||
-      this.alternativeHost ||
+    this.nextVersionHost =
+      storedNextVersionValue ||
+      this.nextVersionHost ||
       (window as {
-        _alternative_sync_server?: string;
-      })._alternative_sync_server;
+        _next_version_sync_server?: string;
+      })._next_version_sync_server;
   }
 
   public async setHost(host: string): Promise<void> {
@@ -159,13 +159,13 @@ export class SNApiService extends PureService {
     return this.host;
   }
 
-  public async setAlternativeHost(alternativeHost: string): Promise<void> {
-    this.alternativeHost = alternativeHost;
-    await this.storageService.setValue(StorageKey.AlternativeServerHost, alternativeHost);
+  public async setNextVersionHost(nextVersionHost: string): Promise<void> {
+    this.nextVersionHost = nextVersionHost;
+    await this.storageService.setValue(StorageKey.NextVersionServerHost, nextVersionHost);
   }
 
-  public getAlternativeHost(): string | undefined {
-    return this.alternativeHost;
+  public getNextVersionHost(): string | undefined {
+    return this.nextVersionHost;
   }
 
   public async setSession(session: Session, persist = true): Promise<void> {
@@ -333,7 +333,7 @@ export class SNApiService extends PureService {
   }
 
   signOut(): Promise<SignOutResponse> {
-    const url = joinPaths(this.alternativeHost, Paths.v1.signOut);
+    const url = joinPaths(this.nextVersionHost, Paths.v1.signOut);
     return this.httpService
       .postAbsolute(url, undefined, this.session!.authorizationValue)
       .catch((errorResponse) => {

--- a/packages/snjs/lib/storage_keys.ts
+++ b/packages/snjs/lib/storage_keys.ts
@@ -19,7 +19,7 @@ export enum StorageKey {
   Session = 'session',
   User = 'user',
   ServerHost = 'server',
-  AlternativeServerHost = 'alternative_server',
+  NextVersionServerHost = 'next_version_server',
   LegacyUuid = 'uuid',
   LastSyncToken = 'syncToken',
   PaginationToken = 'cursorToken',

--- a/packages/snjs/lib/storage_keys.ts
+++ b/packages/snjs/lib/storage_keys.ts
@@ -19,6 +19,7 @@ export enum StorageKey {
   Session = 'session',
   User = 'user',
   ServerHost = 'server',
+  AlternativeServerHost = 'alternative_server',
   LegacyUuid = 'uuid',
   LastSyncToken = 'syncToken',
   PaginationToken = 'cursorToken',

--- a/packages/snjs/package.json
+++ b/packages/snjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@standardnotes/snjs",
-  "version": "2.4.3",
+  "version": "2.5.0",
   "engines": {
     "node": ">=14.0.0 <16.0.0"
   },

--- a/test/lib/factory.js
+++ b/test/lib/factory.js
@@ -91,6 +91,7 @@ export function createApplication(identifier, environment, platform) {
     },
     identifier || `${Math.random()}`,
     [],
+    getDefaultHost(),
     getDefaultHost()
   );
 }

--- a/test/test.html
+++ b/test/test.html
@@ -18,7 +18,7 @@
     const bail = urlParams.get('bail') === 'false' ? false : true;
 
     window._default_sync_server = `http://${syncServerHostName}:3123`;
-    window._alternative_sync_server = `http://${syncServerHostName}:3123`;
+    window._next_version_sync_server = `http://${syncServerHostName}:3123`;
 
     Object.assign(window, SNCrypto);
     Object.assign(window, SNLibrary);

--- a/test/test.html
+++ b/test/test.html
@@ -18,6 +18,7 @@
     const bail = urlParams.get('bail') === 'false' ? false : true;
 
     window._default_sync_server = `http://${syncServerHostName}:3123`;
+    window._alternative_sync_server = `http://${syncServerHostName}:3123`;
 
     Object.assign(window, SNCrypto);
     Object.assign(window, SNLibrary);


### PR DESCRIPTION
- added the `alternativeHost` property so that we can switch endpoints one by one to an upgraded version of the API. Will come in handy when switching to for example `v2` as well in future. The naming could be better than `alternativeHost` I guess so I'm open for propositions.
- switched the sign out action to utilize API `v1` instead of `v0`.