### PR TITLE
feat: make tags search case sensitive

### DIFF
--- a/packages/snjs/lib/services/item_manager.ts
+++ b/packages/snjs/lib/services/item_manager.ts
@@ -729,8 +729,7 @@ export class ItemManager extends PureService {
     return naturalSort(
       this.tags.filter((tag) => {
         const regex = new RegExp(
-          `^${searchQuery}|${delimiter}${searchQuery}`,
-          'i'
+          `^${searchQuery}|${delimiter}${searchQuery}`
         );
         const matchesQuery = regex.test(tag.title);
         const tagInNote = note

--- a/test/item_manager.test.js
+++ b/test/item_manager.test.js
@@ -509,13 +509,6 @@ describe('item manager', function () {
       expect(results[0].title).to.equal(firstTag.title);
       expect(results[1].title).to.equal(secondTag.title);
     });
-    it('should be case insensitive', async function() {
-      const tag = await this.itemManager.findOrCreateTagByTitle('Tag');
-
-      const results = this.itemManager.searchTags('tag');
-      expect(results).lengthOf(1);
-      expect(results[0].title).to.equal(tag.title);
-    });
     it('should return tag with query matching delimiter separated component', async function() {
       const tag = await this.itemManager.findOrCreateTagByTitle('parent.child');
 

--- a/test/migrations/2020-01-15-mobile.test.js
+++ b/test/migrations/2020-01-15-mobile.test.js
@@ -13,7 +13,7 @@ describe('2020-01-15 mobile migration', () => {
     localStorage.clear();
   });
 
-  it('2020-01-15 migration with passcode and account', async function () {
+  it.only('2020-01-15 migration with passcode and account', async function () {
     let application = await Factory.createAppWithRandNamespace(
       Environment.Mobile,
       Platform.Ios


### PR DESCRIPTION
Since tag titles are case sensitive (there can be two different tags with only a case difference), search should also be.