### PR TITLE
feat: add getTagDescendants

### DIFF
--- a/packages/snjs/lib/application.ts
+++ b/packages/snjs/lib/application.ts
@@ -798,6 +798,15 @@ export class SNApplication {
   }
 
   /**
+   * Returns all descendants for a tag
+   * @param tag - The tag for which descendants need to be found
+   * @returns Array containing all descendant tags
+   */
+   public getTagDescendants(tag: SNTag): SNTag[] {
+    return this.itemManager.getTagDescendants(tag);
+  }
+
+  /**
    * Get tags for a note sorted in natural order
    * @param note - The note whose tags will be returned
    * @returns Array containing tags associated with a note

--- a/packages/snjs/lib/services/item_manager.ts
+++ b/packages/snjs/lib/services/item_manager.ts
@@ -772,6 +772,22 @@ export class ItemManager extends PureService {
   }
 
   /**
+   * Returns all descendants for a tag
+   * @param tag - The tag for which descendants need to be found
+   * @returns Array containing all descendant tags
+   */
+   public getTagDescendants(tag: SNTag): SNTag[] {
+    const delimiter = '.';
+    return this.tags.filter((t) => {
+      const regex = new RegExp(
+        `^${tag.title}${delimiter}`,
+        'i'
+      );
+      return regex.test(t.title);
+    });
+  }
+
+  /**
    * Get tags for a note sorted in natural order
    * @param note - The note whose tags will be returned
    * @returns Array containing tags associated with a note

--- a/packages/snjs/lib/services/item_manager.ts
+++ b/packages/snjs/lib/services/item_manager.ts
@@ -780,7 +780,7 @@ export class ItemManager extends PureService {
     const delimiter = '.';
     return this.tags.filter((t) => {
       const regex = new RegExp(
-        `^${tag.title}${delimiter}`,
+        `^${tag.title}${delimiter}|${delimiter}${tag.title}${delimiter}`,
         'i'
       );
       return regex.test(t.title);

--- a/packages/snjs/package.json
+++ b/packages/snjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@standardnotes/snjs",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "engines": {
     "node": ">=14.0.0 <16.0.0"
   },

--- a/test/item_manager.test.js
+++ b/test/item_manager.test.js
@@ -607,7 +607,7 @@ describe('item manager', function () {
   });
 
   describe('getTagDescendants', async function () {
-    it.only('should return descendant tags for a tag', async function () {
+    it('should return descendant tags for a tag', async function () {
       const parentTag = await this.itemManager.findOrCreateTagByTitle('parent');
       const childrenTags = [
         await this.itemManager.findOrCreateTagByTitle('parent.firstChild'),

--- a/test/item_manager.test.js
+++ b/test/item_manager.test.js
@@ -609,7 +609,7 @@ describe('item manager', function () {
   describe('getTagDescendants', async function () {
     it('should return descendant tags for a tag', async function () {
       const parentTag = await this.itemManager.findOrCreateTagByTitle('parent');
-      const childrenTags = [
+      const descendantTags = [
         await this.itemManager.findOrCreateTagByTitle('parent.firstChild'),
         await this.itemManager.findOrCreateTagByTitle('parent.firstChild.grandchild'),
         await this.itemManager.findOrCreateTagByTitle('parent.secondChild'),
@@ -617,9 +617,10 @@ describe('item manager', function () {
       await this.itemManager.findOrCreateTagByTitle('some other tag');
 
       const results = this.itemManager.getTagDescendants(parentTag);
-      expect(results).lengthOf(childrenTags.length);
-      expect(results).to.contain(childrenTags[0]);
-      expect(results).to.contain(childrenTags[1]);
+      expect(results).lengthOf(descendantTags.length);
+      expect(results).to.contain(descendantTags[0]);
+      expect(results).to.contain(descendantTags[1]);
+      expect(results).to.contain(descendantTags[2]);
     })
   })
 });

--- a/test/item_manager.test.js
+++ b/test/item_manager.test.js
@@ -604,5 +604,22 @@ describe('item manager', function () {
       expect(results).to.contain(parentTags[0]);
       expect(results).to.contain(parentTags[1]);
     })
+  });
+
+  describe('getTagDescendants', async function () {
+    it.only('should return descendant tags for a tag', async function () {
+      const parentTag = await this.itemManager.findOrCreateTagByTitle('parent');
+      const childrenTags = [
+        await this.itemManager.findOrCreateTagByTitle('parent.firstChild'),
+        await this.itemManager.findOrCreateTagByTitle('parent.firstChild.grandchild'),
+        await this.itemManager.findOrCreateTagByTitle('parent.secondChild'),
+      ];
+      await this.itemManager.findOrCreateTagByTitle('some other tag');
+
+      const results = this.itemManager.getTagDescendants(parentTag);
+      expect(results).lengthOf(childrenTags.length);
+      expect(results).to.contain(childrenTags[0]);
+      expect(results).to.contain(childrenTags[1]);
+    })
   })
 });

--- a/test/item_manager.test.js
+++ b/test/item_manager.test.js
@@ -607,7 +607,7 @@ describe('item manager', function () {
   });
 
   describe('getTagDescendants', async function () {
-    it('should return descendant tags for a tag', async function () {
+    it('should return descendant tags for a parent tag', async function () {
       const parentTag = await this.itemManager.findOrCreateTagByTitle('parent');
       const descendantTags = [
         await this.itemManager.findOrCreateTagByTitle('parent.firstChild'),
@@ -621,6 +621,20 @@ describe('item manager', function () {
       expect(results).to.contain(descendantTags[0]);
       expect(results).to.contain(descendantTags[1]);
       expect(results).to.contain(descendantTags[2]);
+    })
+
+    it('should return descendant tags for a child tag', async function () {
+      const childTag = await this.itemManager.findOrCreateTagByTitle('parent.child');
+      const descendantTags = [
+        await this.itemManager.findOrCreateTagByTitle('parent.child.firstGrandchild'),
+        await this.itemManager.findOrCreateTagByTitle('parent.child.secondGrandchild'),
+      ];
+      await this.itemManager.findOrCreateTagByTitle('some other tag');
+
+      const results = this.itemManager.getTagDescendants(childTag);
+      expect(results).lengthOf(descendantTags.length);
+      expect(results).to.contain(descendantTags[0]);
+      expect(results).to.contain(descendantTags[1]);
     })
   })
 });


### PR DESCRIPTION
Added getTagDescendants method, which will allow us to remove any descendant tags when a user removes a parent tag from a note.