### PR TITLE
feat: make webSocketUrl optional

### DIFF
--- a/packages/snjs/lib/application.ts
+++ b/packages/snjs/lib/application.ts
@@ -187,7 +187,7 @@ export class SNApplication {
     public identifier: ApplicationIdentifier,
     private swapClasses: { swap: any; with: any }[],
     private defaultHost: string,
-    private webSocketUrl: string,
+    private webSocketUrl?: string,
   ) {
     if (!SNLog.onLog) {
       throw Error('SNLog.onLog must be set.');

--- a/packages/snjs/package.json
+++ b/packages/snjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@standardnotes/snjs",
-  "version": "2.7.19",
+  "version": "2.7.20",
   "engines": {
     "node": ">=14.0.0 <16.0.0"
   },


### PR DESCRIPTION
Make webSocketUrl optional on SNApplication, so clients won't connect to the WebSocket if they don't include this in the constructor.