### PR TITLE
feat: add user role changed event for websockets purposes

### DIFF
--- a/packages/domain-events/package.json
+++ b/packages/domain-events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@standardnotes/domain-events",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "engines": {
     "node": ">=14.0.0 <16.0.0"
   },

--- a/packages/domain-events/src/Domain/Event/UserRoleChangedEvent.ts
+++ b/packages/domain-events/src/Domain/Event/UserRoleChangedEvent.ts
@@ -1,0 +1,7 @@
+import { DomainEventInterface } from './DomainEventInterface'
+import { UserRoleChangedEventPayload } from './UserRoleChangedEventPayload'
+
+export interface UserRoleChangedEvent extends DomainEventInterface {
+  type: 'USER_ROLE_CHANGED'
+  payload: UserRoleChangedEventPayload
+}

--- a/packages/domain-events/src/Domain/Event/UserRoleChangedEventPayload.ts
+++ b/packages/domain-events/src/Domain/Event/UserRoleChangedEventPayload.ts
@@ -1,0 +1,9 @@
+import { RoleName } from '@standardnotes/auth'
+
+export interface UserRoleChangedEventPayload {
+  userUuid: string
+  email: string
+  fromRole: RoleName
+  toRole: RoleName
+  timestamp: number
+}

--- a/packages/domain-events/src/Domain/index.ts
+++ b/packages/domain-events/src/Domain/index.ts
@@ -27,6 +27,8 @@ export * from './Event/SubscriptionRenewedEvent'
 export * from './Event/SubscriptionRenewedEventPayload'
 export * from './Event/UserRegisteredEvent'
 export * from './Event/UserRegisteredEventPayload'
+export * from './Event/UserRoleChangedEvent'
+export * from './Event/UserRoleChangedEventPayload'
 
 export * from './Handler/DomainEventHandlerInterface'
 export * from './Handler/DomainEventMessageHandlerInterface'


### PR DESCRIPTION
I was thinking about the events structure that we are going to utilize in the websockets communication and I think the events that we already use for SNS/SQS are good for using in websockets as well. So it's enough if we publish a `USER_ROLE_CHANGED` event via websockets and the client will know to re-fresh features based on that. @antsgar wdyt?