### PR TITLE
chore: Bump @standardnotes/features to 1.7.1

### DIFF
--- a/packages/snjs/package.json
+++ b/packages/snjs/package.json
@@ -79,7 +79,7 @@
     "@standardnotes/auth": "3.7.2",
     "@standardnotes/common": "1.2.0",
     "@standardnotes/domain-events": "2.1.0",
-    "@standardnotes/features": "1.6.2",
+    "@standardnotes/features": "1.7.1",
     "@standardnotes/settings": "1.2.0",
     "@standardnotes/sncrypto-common": "1.5.2"
   }

--- a/packages/snjs/package.json
+++ b/packages/snjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@standardnotes/snjs",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "engines": {
     "node": ">=14.0.0 <16.0.0"
   },


### PR DESCRIPTION
Bump `@standardnotes/features` version to 1.7.1 to possibly fix errors mentioned here: https://github.com/standardnotes/web/pull/688#discussion_r731125408