### PR TITLE
fix: remove running tests upon deployment - ensured on PR status checks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,46 +5,7 @@ on:
     branches: [ master ]
 
 jobs:
-  lint:
-    if: contains(github.event.head_commit.message, 'chore(release)') == false
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '16.x'
-          registry-url: 'https://registry.npmjs.org'
-      - run: yarn install --pure-lockfile
-      - run: yarn build
-      - run: yarn lint
-  unit-tests:
-    if: contains(github.event.head_commit.message, 'chore(release)') == false
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '16.x'
-          registry-url: 'https://registry.npmjs.org'
-      - run: yarn install --pure-lockfile
-      - run: yarn build
-      - run: yarn test:unit
-  e2e-tests:
-    if: contains(github.event.head_commit.message, 'chore(release)') == false
-    env:
-      DOCKER_BUILDKIT: 1
-      COMPOSE_DOCKER_CLI_BUILD: 1
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '16.x'
-          registry-url: 'https://registry.npmjs.org'
-      - run: yarn test:e2e
-
   publish:
-    needs: [lint, unit-tests, e2e-tests]
     if: contains(github.event.head_commit.message, 'chore(release)') == false
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Remove the tests upon deployment aka master push. I've made the lint, unit test and e2e test status checks required on all PRs and also added the requirement that a PR has to be in sync with the latest master so now it's redundant to run those once again whenever a PR is merged to master. This would cut the time-to-publish time in half.

## Related Issue(s)

N/A

## Checklist

- [x] This PR has NO tests
