### PR TITLE
fix: add missing canceled property from subscription sync requested event

### DIFF
--- a/packages/domain-events/src/Domain/Event/SubscriptionSyncRequestedEventPayload.ts
+++ b/packages/domain-events/src/Domain/Event/SubscriptionSyncRequestedEventPayload.ts
@@ -7,6 +7,7 @@ export interface SubscriptionSyncRequestedEventPayload {
   subscriptionExpiresAt: number
   timestamp: number
   offline: boolean
+  canceled: boolean
   extensionKey: string
   offlineFeaturesToken: string
   payAmount: number | null


### PR DESCRIPTION
## Description

Add `canceled` property missing from sync payload.

## Related Issue(s)

https://app.asana.com/0/1200980603427038/1201573386680719/f

## Checklist

- [x] This PR has NO tests
