### PR TITLE
fix: cross-package dependencies and content type imports

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -25,7 +25,7 @@
     "test:unit": "yarn lint"
   },
   "dependencies": {
-    "@standardnotes/common": "1.2.1",
+    "@standardnotes/common": "^1.7.0",
     "jsonwebtoken": "^8.5.1"
   },
   "devDependencies": {

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -22,8 +22,8 @@
     "lint": "eslint . --ext .ts"
   },
   "dependencies": {
-    "@standardnotes/auth": "3.8.3",
-    "@standardnotes/common": "1.2.1"
+    "@standardnotes/auth": "^3.13.0",
+    "@standardnotes/common": "^1.7.0"
   },
   "devDependencies": {
     "@standardnotes/config": "^2.2.0",

--- a/packages/snjs/lib/application.ts
+++ b/packages/snjs/lib/application.ts
@@ -58,7 +58,7 @@ import {
   removeFromArray,
   sleep,
 } from '@Lib/utils';
-import { ContentType } from '@Models/content_types';
+import { ContentType } from '@standardnotes/common';
 import {
   CopyPayload,
   CreateMaxPayloadFromAnyObject,

--- a/packages/snjs/lib/index.ts
+++ b/packages/snjs/lib/index.ts
@@ -175,9 +175,9 @@ export {
   ContentTypeUsesRootKeyEncryption,
 } from '@Protocol/intents';
 export {
-  ContentType,
   displayStringForContentType,
 } from '@Models/content_types';
+export { ContentType } from '@standardnotes/common';
 export { CreateItemFromPayload } from '@Models/generator';
 export { Uuids, FillItemContent } from '@Models/functions';
 

--- a/packages/snjs/lib/migrations/2_0_0.ts
+++ b/packages/snjs/lib/migrations/2_0_0.ts
@@ -3,7 +3,7 @@ import { MigrationServices } from './types';
 import { PreviousSnjsVersion2_0_0 } from './../version';
 import { LegacyKeys1_0_0, NonwrappedStorageKey } from './../storage_keys';
 import { JwtSession } from './../services/api/session';
-import { ContentType } from './../models/content_types';
+import { ContentType } from '@standardnotes/common';
 import { SNItemsKey } from './../models/app/items_key';
 import { RootKeyContent, SNRootKey } from './../protocol/root_key';
 import { EncryptionIntent } from './../protocol/intents';

--- a/packages/snjs/lib/migrations/2_20_0.ts
+++ b/packages/snjs/lib/migrations/2_20_0.ts
@@ -1,6 +1,6 @@
 import { ApplicationStage } from '../stages';
 import { Migration } from '@Lib/migrations/migration';
-import { ContentType } from '@Lib/models';
+import { ContentType } from '@standardnotes/common';
 
 export class Migration2_20_0 extends Migration {
   static version(): string {

--- a/packages/snjs/lib/migrations/2_7_0.ts
+++ b/packages/snjs/lib/migrations/2_7_0.ts
@@ -1,6 +1,7 @@
 import { ApplicationStage } from '../stages';
 import { Migration } from '@Lib/migrations/migration';
-import { ContentType, SNPredicate } from '@Lib/models';
+import { SNPredicate } from '@Lib/models';
+import { ContentType } from '@standardnotes/common';
 
 export class Migration2_7_0 extends Migration {
   static version(): string {

--- a/packages/snjs/lib/models/app/component.ts
+++ b/packages/snjs/lib/models/app/component.ts
@@ -5,7 +5,7 @@ import { UuidString } from './../../types';
 import { AppDataField } from './../core/item';
 import { PurePayload } from '@Payloads/pure_payload';
 import { ItemMutator, SNItem } from '@Models/core/item';
-import { ContentType } from '@Models/content_types';
+import { ContentType } from '@standardnotes/common';
 import { HistoryEntry } from '@Lib/services/history/entries/history_entry';
 import {
   ComponentArea,

--- a/packages/snjs/lib/models/app/tag.ts
+++ b/packages/snjs/lib/models/app/tag.ts
@@ -1,5 +1,5 @@
 import { ContentReference } from '@Lib/protocol/payloads/generator';
-import { ContentType } from '@Models/content_types';
+import { ContentType } from '@standardnotes/common';
 import { ItemMutator, SNItem } from '@Models/core/item';
 import { PurePayload } from '@Protocol/payloads/pure_payload';
 import { UuidString } from './../../types';

--- a/packages/snjs/lib/models/app/userPrefs.ts
+++ b/packages/snjs/lib/models/app/userPrefs.ts
@@ -1,7 +1,7 @@
 import { ItemMutator, SNItem } from '@Models/core/item';
 import { CollectionSort } from '@Lib/protocol/collection/item_collection';
 import { SNPredicate } from '@Models/core/predicate';
-import { ContentType } from '../content_types';
+import { ContentType } from '@standardnotes/common';
 
 export enum PrefKey {
   TagsPanelWidth = 'tagsPanelWidth',

--- a/packages/snjs/lib/models/content_types.ts
+++ b/packages/snjs/lib/models/content_types.ts
@@ -2,8 +2,6 @@ import { ContentType } from '@standardnotes/common';
 
 export const DefaultAppDomain = 'org.standardnotes.sn';
 
-export { ContentType };
-
 export function displayStringForContentType(
   contentType: ContentType
 ): string | undefined {

--- a/packages/snjs/lib/models/generator.ts
+++ b/packages/snjs/lib/models/generator.ts
@@ -1,5 +1,5 @@
 import { SNFeatureRepo } from './app/feature_repo';
-import { ContentType } from '@Models/content_types';
+import { ContentType } from '@standardnotes/common';
 import { PurePayload } from '@Payloads/pure_payload';
 import { SNActionsExtension } from './app/extension';
 import { SNComponent } from '@Models/app/component';

--- a/packages/snjs/lib/models/index.ts
+++ b/packages/snjs/lib/models/index.ts
@@ -21,7 +21,6 @@ export { SNSmartTag } from '@Models/app/smartTag';
 export { SNTheme, ThemeMutator } from '@Models/app/theme';
 
 export {
-  ContentType,
   displayStringForContentType,
 } from '@Models/content_types';
 export { CreateItemFromPayload } from '@Models/generator';

--- a/packages/snjs/lib/models/live_item.ts
+++ b/packages/snjs/lib/models/live_item.ts
@@ -1,4 +1,4 @@
-import { ContentType } from '@Models/content_types';
+import { ContentType } from '@standardnotes/common';
 import { SNApplication } from './../application';
 import { SNItem } from '@Models/core/item';
 

--- a/packages/snjs/lib/models/mutator.ts
+++ b/packages/snjs/lib/models/mutator.ts
@@ -6,7 +6,7 @@ import { ActionsExtensionMutator } from './app/extension';
 import { ComponentMutator } from './app/component';
 import { TagMutator } from './app/tag';
 import { NoteMutator } from './app/note';
-import { ContentType } from './content_types';
+import { ContentType } from '@standardnotes/common';
 
 export function createMutatorForItem(
   item: SNItem,

--- a/packages/snjs/lib/protocol/collection/collection.ts
+++ b/packages/snjs/lib/protocol/collection/collection.ts
@@ -2,7 +2,7 @@ import { UuidMap } from './uuid_map';
 import { extendArray, isString } from '@Lib/utils';
 import { SNItem } from './../../models/core/item';
 import remove from 'lodash/remove';
-import { ContentType } from '@Models/content_types';
+import { ContentType } from '@standardnotes/common';
 import { UuidString } from './../../types';
 import { PurePayload } from '@Payloads/pure_payload';
 

--- a/packages/snjs/lib/protocol/collection/item_collection.ts
+++ b/packages/snjs/lib/protocol/collection/item_collection.ts
@@ -1,7 +1,7 @@
 import { MutableCollection } from './collection';
 import { compareValues, isNullOrUndefined, uniqueArrayByKey } from '@Lib/utils';
 import { SNItem } from './../../models/core/item';
-import { ContentType } from '@Models/content_types';
+import { ContentType } from '@standardnotes/common';
 import { UuidString } from './../../types';
 
 export enum CollectionSort {

--- a/packages/snjs/lib/protocol/collection/item_collection_notes_view.ts
+++ b/packages/snjs/lib/protocol/collection/item_collection_notes_view.ts
@@ -1,6 +1,7 @@
 import { SNSmartTag } from './../../models/app/smartTag';
 import { ItemCollection } from './item_collection';
-import { ContentType, SNNote, SNTag } from '../../models';
+import { SNNote, SNTag } from '../../models';
+import { ContentType } from '@standardnotes/common';
 import {
   criteriaForSmartTag,
   NotesDisplayCriteria,

--- a/packages/snjs/lib/protocol/collection/notes_display_criteria.ts
+++ b/packages/snjs/lib/protocol/collection/notes_display_criteria.ts
@@ -2,7 +2,7 @@ import { SortDirection } from './item_collection';
 import { CollectionSort } from '@Lib/protocol/collection/item_collection';
 import { SNTag } from './../../models/app/tag';
 import { SNPredicate } from './../../models/core/predicate';
-import { ContentType } from './../../models/content_types';
+import { ContentType } from '@standardnotes/common';
 import { ItemCollection } from './item_collection';
 import { SNNote } from './../../models/app/note';
 import { SNSmartTag } from './../../models/app/smartTag';

--- a/packages/snjs/lib/protocol/collection/payload_collection.ts
+++ b/packages/snjs/lib/protocol/collection/payload_collection.ts
@@ -1,5 +1,5 @@
 import { PayloadSource } from '@Payloads/sources';
-import { ContentType } from '@Models/content_types';
+import { ContentType } from '@standardnotes/common';
 import { UuidString } from './../../types';
 import { PurePayload } from '@Payloads/pure_payload';
 import { MutableCollection } from './collection';

--- a/packages/snjs/lib/protocol/intents.ts
+++ b/packages/snjs/lib/protocol/intents.ts
@@ -1,4 +1,4 @@
-import { ContentType } from './../models/content_types';
+import { ContentType } from '@standardnotes/common';
 /**
  * Only three types of items should be encrypted with a root key:
  * - A root key is encrypted with another root key in the case of root key wrapping

--- a/packages/snjs/lib/protocol/operator/operator.ts
+++ b/packages/snjs/lib/protocol/operator/operator.ts
@@ -18,7 +18,7 @@ import {
 } from '@Payloads/generator';
 import { ProtocolVersion } from '@Protocol/versions';
 import { SNPureCrypto } from '@standardnotes/sncrypto-common';
-import { ContentType } from '@Lib/models';
+import { ContentType } from '@standardnotes/common';
 
 export type ItemsKeyContent = {
   itemsKey: string;

--- a/packages/snjs/lib/protocol/payloads/functions.ts
+++ b/packages/snjs/lib/protocol/payloads/functions.ts
@@ -12,7 +12,7 @@ import { CopyPayload, PayloadOverride } from '@Payloads/generator';
 import { extendArray } from '@Lib/utils';
 import { Uuid } from '@Lib/uuid';
 import { PurePayload } from '@Payloads/pure_payload';
-import { ContentType } from '@Lib/models';
+import { ContentType } from '@standardnotes/common';
 
 type AffectorFunction = (
   basePayload: PurePayload,

--- a/packages/snjs/lib/protocol/payloads/generator.ts
+++ b/packages/snjs/lib/protocol/payloads/generator.ts
@@ -3,7 +3,7 @@ import { ProtocolVersion } from './../versions';
 import { UuidString } from './../../types';
 import { PurePayload } from '@Payloads/pure_payload';
 import { PayloadSource } from '@Payloads/sources';
-import { ContentType } from '@Models/content_types';
+import { ContentType } from '@standardnotes/common';
 import { EncryptionIntent } from '@Protocol/intents';
 import { Copy, pickByCopy, uniqueArray } from '@Lib/utils';
 import { PayloadField } from '@Payloads/fields';

--- a/packages/snjs/lib/protocol/payloads/pure_payload.ts
+++ b/packages/snjs/lib/protocol/payloads/pure_payload.ts
@@ -1,7 +1,7 @@
 import { FillItemContent } from '@Models/functions';
 import { PayloadField } from './fields';
 import { PayloadSource } from '@Payloads/sources';
-import { ContentType } from '@Models/content_types';
+import { ContentType } from '@standardnotes/common';
 import { ProtocolVersion } from '@Protocol/versions';
 import { deepFreeze, isNullOrUndefined, isObject, isString } from '@Lib/utils';
 import { ContentReference, PayloadContent, RawPayload } from '@Payloads/generator';

--- a/packages/snjs/lib/protocol/root_key.ts
+++ b/packages/snjs/lib/protocol/root_key.ts
@@ -3,7 +3,7 @@ import { AnyKeyParamsContent, SNRootKeyParams } from './key_params';
 import { FillItemContent } from '@Models/functions';
 import { CreateMaxPayloadFromAnyObject } from '@Payloads/generator';
 import { SNItem } from '@Models/core/item';
-import { ContentType } from '@Models/content_types';
+import { ContentType } from '@standardnotes/common';
 import { ProtocolVersion } from '@Protocol/versions';
 import { Uuid } from '@Lib/uuid';
 import { timingSafeEqual } from '@standardnotes/sncrypto-common';

--- a/packages/snjs/lib/services/actions_service.ts
+++ b/packages/snjs/lib/services/actions_service.ts
@@ -1,7 +1,7 @@
 import { CreateItemFromPayload } from '@Models/generator';
 import { HttpResponse } from './api/responses';
 import { Action, ActionAccessType } from './../models/app/action';
-import { ContentType } from './../models/content_types';
+import { ContentType } from '@standardnotes/common';
 import { ItemManager } from '@Services/item_manager';
 import { PurePayload } from '@Payloads/pure_payload';
 import { SNRootKey } from '@Protocol/root_key';

--- a/packages/snjs/lib/services/api/api_service.ts
+++ b/packages/snjs/lib/services/api/api_service.ts
@@ -28,7 +28,7 @@ import {
   GetOfflineFeaturesResponse,
 } from './responses';
 import { Session, TokenSession } from './session';
-import { ContentType } from '@Models/content_types';
+import { ContentType } from '@standardnotes/common';
 import { PurePayload } from '@Payloads/pure_payload';
 import { SNRootKeyParams } from './../../protocol/key_params';
 import { SNStorageService } from './../storage_service';

--- a/packages/snjs/lib/services/component_manager.spec.ts
+++ b/packages/snjs/lib/services/component_manager.spec.ts
@@ -5,7 +5,7 @@
 import { FeatureDescription } from '@standardnotes/features';
 import { DesktopManagerInterface } from '@Services/component_manager/types';
 import { FeatureIdentifier } from '@standardnotes/features';
-import { ContentType } from '@Models/content_types';
+import { ContentType } from '@standardnotes/common';
 import { SNComponent } from '@Lib/models';
 import { Environment, Platform } from '@Lib/platforms';
 import { SNAlertService } from '@Services/alert_service';

--- a/packages/snjs/lib/services/component_manager.ts
+++ b/packages/snjs/lib/services/component_manager.ts
@@ -1,10 +1,8 @@
 import { Features, FeatureDescription } from '@standardnotes/features';
 import { SNFeaturesService } from '@Services/features_service';
 import { ComponentMutator } from '@Models/app/component';
-import {
-  ContentType,
-  displayStringForContentType,
-} from '@Models/content_types';
+import { displayStringForContentType } from '@Models/content_types';
+import { ContentType } from '@standardnotes/common';
 import { PayloadSource } from '@Protocol/payloads/sources';
 import { ItemManager } from '@Services/item_manager';
 import { SNNote } from '@Models/app/note';

--- a/packages/snjs/lib/services/component_manager/component_viewer.ts
+++ b/packages/snjs/lib/services/component_manager/component_viewer.ts
@@ -36,7 +36,7 @@ import { PayloadSource } from '@Lib/protocol/payloads';
 import { ItemManager } from '@Services/item_manager';
 import { UuidString } from '@Lib/types';
 import { SNItem, MutationType } from '@Models/core/item';
-import { ContentType } from '@Models/content_types';
+import { ContentType } from '@standardnotes/common';
 import { SNComponent } from '@Lib/models';
 import {
   concatArrays,

--- a/packages/snjs/lib/services/component_manager/types.ts
+++ b/packages/snjs/lib/services/component_manager/types.ts
@@ -2,7 +2,7 @@ import { ComponentAction, ComponentPermission } from '@standardnotes/features';
 import { SNComponent } from '@Lib/models';
 import { ComponentArea } from '@Models/app/component';
 import { UuidString } from '@Lib/types';
-import { ContentType } from '@Models/content_types';
+import { ContentType } from '@standardnotes/common';
 import { RawPayload } from '@Payloads/generator';
 
 export interface DesktopManagerInterface {

--- a/packages/snjs/lib/services/history/entries/generator.ts
+++ b/packages/snjs/lib/services/history/entries/generator.ts
@@ -1,5 +1,5 @@
 import { PayloadField } from '@Protocol/payloads/fields';
-import { ContentType } from '@Models/content_types';
+import { ContentType } from '@standardnotes/common';
 import { SurePayload } from '@Lib/protocol/payloads/sure_payload';
 import { HistoryEntry } from './history_entry';
 import { NoteHistoryEntry } from './note_history_entry';

--- a/packages/snjs/lib/services/history/history_manager.ts
+++ b/packages/snjs/lib/services/history/history_manager.ts
@@ -16,7 +16,7 @@ import {
   CreateSourcedPayloadFromObject,
 } from '@Payloads/generator';
 import { SNItem } from '@Models/core/item';
-import { ContentType } from '@Models/content_types';
+import { ContentType } from '@standardnotes/common';
 import { PureService } from '@Lib/services/pure_service';
 import { PayloadSource } from '@Payloads/sources';
 import { StorageKey } from '@Lib/storage_keys';

--- a/packages/snjs/lib/services/item_manager.ts
+++ b/packages/snjs/lib/services/item_manager.ts
@@ -15,7 +15,7 @@ import {
   ItemCollection,
   SortDirection,
 } from '@Protocol/collection/item_collection';
-import { ContentType } from '../models/content_types';
+import { ContentType } from '@standardnotes/common'
 import { ComponentMutator } from './../models/app/component';
 import {
   ActionsExtensionMutator,

--- a/packages/snjs/lib/services/key_recovery_service.ts
+++ b/packages/snjs/lib/services/key_recovery_service.ts
@@ -22,7 +22,7 @@ import { SNRootKey } from '@Protocol/root_key';
 import { SNProtocolService } from '@Lib/services/protocol_service';
 import { SNApiService } from '@Lib/services/api/api_service';
 import { SNItemsKey } from './../models/app/items_key';
-import { ContentType } from './../models/content_types';
+import { ContentType } from '@standardnotes/common';
 import { ItemManager } from './item_manager';
 import { PureService } from '@Services/pure_service';
 import { dateSorted, isNullOrUndefined, removeFromArray } from '@Lib/utils';

--- a/packages/snjs/lib/services/payload_manager.ts
+++ b/packages/snjs/lib/services/payload_manager.ts
@@ -2,7 +2,7 @@ import { removeFromArray } from '@Lib/utils';
 import { PayloadByMerging } from '@Lib/protocol/payloads/generator';
 import { DeltaFileImport } from './../protocol/payloads/deltas/file_import';
 import { PayloadSource } from './../protocol/payloads/sources';
-import { ContentType } from './../models/content_types';
+import { ContentType } from '@standardnotes/common';
 import { Uuids } from '@Models/functions';
 import { UuidString } from './../types';
 import { PurePayload } from '@Payloads/pure_payload';

--- a/packages/snjs/lib/services/preferences_service.ts
+++ b/packages/snjs/lib/services/preferences_service.ts
@@ -1,4 +1,5 @@
-import { ContentType, SNUserPrefs } from '@Lib/models';
+import { SNUserPrefs } from '@Lib/models';
+import { ContentType } from '@standardnotes/common';
 import {
   PrefKey,
   PrefValue,

--- a/packages/snjs/lib/services/protocol_service.ts
+++ b/packages/snjs/lib/services/protocol_service.ts
@@ -55,7 +55,7 @@ import {
   removeFromArray,
 } from '@Lib/utils';
 import { V001Algorithm, V002Algorithm } from '../protocol/operator/algorithms';
-import { ContentType } from '@Models/content_types';
+import { ContentType } from '@standardnotes/common';
 import { StorageKey } from '@Lib/storage_keys';
 import { StorageValueModes } from '@Lib/services/storage_service';
 import { DeviceInterface } from '../device_interface';

--- a/packages/snjs/lib/services/singleton_manager.ts
+++ b/packages/snjs/lib/services/singleton_manager.ts
@@ -1,4 +1,4 @@
-import { ContentType } from './../models/content_types';
+import { ContentType } from '@standardnotes/common';
 import { ItemManager } from '@Services/item_manager';
 import { SNPredicate } from '@Models/core/predicate';
 import { SNItem, SingletonStrategy } from '@Models/core/item';

--- a/packages/snjs/lib/services/storage_service.ts
+++ b/packages/snjs/lib/services/storage_service.ts
@@ -13,7 +13,7 @@ import { EncryptionIntent } from '@Protocol/intents';
 import { SNRootKey } from '@Protocol/root_key';
 import { PurePayload } from '@Payloads/pure_payload';
 import { PureService } from '@Lib/services/pure_service';
-import { ContentType } from '@Models/content_types';
+import { ContentType } from '@standardnotes/common';
 import { Copy, isNullOrUndefined } from '@Lib/utils';
 import { Uuid } from '@Lib/uuid';
 import { DeviceInterface } from '../device_interface';

--- a/packages/snjs/lib/services/sync/account/downloader.ts
+++ b/packages/snjs/lib/services/sync/account/downloader.ts
@@ -1,6 +1,6 @@
 import { filterDisallowedRemotePayloads } from '@Lib/services/sync/filter';
 import { PurePayload } from '@Payloads/pure_payload';
-import { ContentType } from '@Models/content_types';
+import { ContentType } from '@standardnotes/common';
 import {
   RawPayload,
   CreateSourcedPayloadFromObject,

--- a/packages/snjs/lib/services/sync/filter.ts
+++ b/packages/snjs/lib/services/sync/filter.ts
@@ -1,4 +1,4 @@
-import { ContentType } from '@Lib/models';
+import { ContentType } from '@standardnotes/common';
 import { PayloadFormat, PurePayload } from '@Lib/protocol/payloads';
 
 /**

--- a/packages/snjs/lib/services/sync/sync_service.ts
+++ b/packages/snjs/lib/services/sync/sync_service.ts
@@ -31,7 +31,7 @@ import { ImmutablePayloadCollection } from '@Protocol/collection/payload_collect
 import { PayloadsByAlternatingUuid } from '@Payloads/functions';
 import { CreateMaxPayloadFromAnyObject } from '@Payloads/generator';
 import { EncryptionIntent } from '@Protocol/intents';
-import { ContentType } from '@Models/content_types';
+import { ContentType } from '@standardnotes/common';
 import { CreateItemFromPayload } from '@Models/generator';
 import { Uuids } from '@Models/functions';
 import { SyncSignal, SyncStats } from '@Services/sync/signals';

--- a/packages/snjs/lib/services/sync/utils.ts
+++ b/packages/snjs/lib/services/sync/utils.ts
@@ -1,4 +1,4 @@
-import { ContentType } from '@Models/content_types';
+import { ContentType } from '@standardnotes/common';
 import { PurePayload } from '@Payloads/pure_payload';
 /**
  * Sorts payloads according by most recently modified first, according to the priority,

--- a/packages/snjs/lib/ui/note_view_controller.ts
+++ b/packages/snjs/lib/ui/note_view_controller.ts
@@ -1,6 +1,6 @@
 import { removeFromArray } from '@Lib/utils';
 import { SNItem } from '@Models/core/item';
-import { ContentType } from '@Models/content_types';
+import { ContentType } from '@standardnotes/common';
 import { SNTag } from '@Lib/index';
 import { PayloadSource } from '@Lib/protocol/payloads';
 import { NoteMutator, SNNote } from '@Lib/models';

--- a/packages/snjs/package.json
+++ b/packages/snjs/package.json
@@ -79,9 +79,9 @@
     "webpack-merge": "^4.2.2"
   },
   "dependencies": {
-    "@standardnotes/auth": "3.8.1",
-    "@standardnotes/common": "1.2.1",
-    "@standardnotes/domain-events": "2.5.1",
+    "@standardnotes/auth": "^3.13.0",
+    "@standardnotes/common": "^1.7.0",
+    "@standardnotes/domain-events": "^2.16.2",
     "@standardnotes/features": "^1.20.7",
     "@standardnotes/settings": "^1.9.0",
     "@standardnotes/sncrypto-common": "1.5.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2523,25 +2523,6 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
-"@standardnotes/auth@3.8.1":
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/@standardnotes/auth/-/auth-3.8.1.tgz#4197fb2f7e223c6bd13a870a3feac3c73294fb3c"
-  integrity sha512-Q2/81dgFGIGuYlQ4VnSjGRsDB0Qw0tQP/qsiuV+DQj+wdp5Wy5WX3Q4g+p2PNvoyEAYgbuduEHZfWuTLAaIdyw==
-  dependencies:
-    "@standardnotes/common" "^1.2.1"
-
-"@standardnotes/auth@3.8.3":
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/@standardnotes/auth/-/auth-3.8.3.tgz#6e627c1a1a9ebf91d97f52950d099bf7704382e3"
-  integrity sha512-wz056b3pv8IIX74lYaqjCUvnw3NSow+ex5pn/VlGxg8r7gq19WsmgyXP2BoE7nqKddO1JMlFok+4gdnutYF0Cw==
-  dependencies:
-    "@standardnotes/common" "^1.2.1"
-
-"@standardnotes/common@1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@standardnotes/common/-/common-1.2.1.tgz#9db212db86ccbf08b347da02549b3dbe4bedbb02"
-  integrity sha512-HilBxS50CBlC6TJvy1mrnhGVDzOH63M/Jf+hyMxQ0Vt1nYzpd0iyxVEUrgMh7ZiyO1b9CLnCDED99Jy9rnZWVQ==
-
 "@standardnotes/deterministic-zip@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@standardnotes/deterministic-zip/-/deterministic-zip-1.2.0.tgz#b5fc2380fcb048a843988768c7e0f44459ef2d2c"
@@ -2550,13 +2531,6 @@
     async "^3.1.0"
     crc32-stream "^3.0.0"
     minimatch "^3.0.3"
-
-"@standardnotes/domain-events@2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@standardnotes/domain-events/-/domain-events-2.5.1.tgz#e6433e940ae616683d1c24f76133c70755504c44"
-  integrity sha512-p0VB4Al/ZcVqcj9ztU7TNqzc3jjjG6/U7x9lBW/QURHxpB+PnwJq3kFU5V5JA9QpCOYlXLT71CMERMf/O5QX6g==
-  dependencies:
-    "@standardnotes/auth" "^3.8.1"
 
 "@standardnotes/filesafe-bar@standardnotes/filesafe-client":
   version "2.0.15"


### PR DESCRIPTION
## Description

Due to cross-package dependencies that were stale and also `ContentType` being defined in a couple of places builds like yarn lint were failing when trying to introduce new changes. 

This is unifying the `ContentType` being always taken from `@standardnotes/common` and also fixes the cross-package deps to be handled and auto-updated by Lerna.

This PR is blocking the following PRs:
- https://github.com/standardnotes/snjs/pull/553
- https://github.com/standardnotes/snjs/pull/554
- https://github.com/standardnotes/snjs/pull/548
- https://github.com/standardnotes/snjs/pull/552

## Related Issue(s)

- [Internal Link](https://app.asana.com/0/1160985268757888/1201657625832220/f)

## Checklist

- [x] This PR has NO tests
