### PR TITLE
refactor: Replace 'None' with 'Default' for AutoThemeIdentifier

### DIFF
--- a/packages/snjs/lib/models/app/userPrefs.ts
+++ b/packages/snjs/lib/models/app/userPrefs.ts
@@ -46,8 +46,8 @@ export type PrefValue = {
   [PrefKey.NotesHideTags]: boolean;
   [PrefKey.NotesHideEditorIcon]: boolean;
   [PrefKey.UseSystemColorScheme]: boolean;
-  [PrefKey.AutoLightThemeIdentifier]: FeatureIdentifier | 'None';
-  [PrefKey.AutoDarkThemeIdentifier]: FeatureIdentifier | 'None';
+  [PrefKey.AutoLightThemeIdentifier]: FeatureIdentifier | 'Default';
+  [PrefKey.AutoDarkThemeIdentifier]: FeatureIdentifier | 'Default';
 };
 
 export class SNUserPrefs extends SNItem {


### PR DESCRIPTION
## Description

Replaces 'None' with 'Default' for the typedef of Auto[..]ThemeIdentifier userPref

## Checklist

- [x] This PR has NO tests
