### PR TITLE
Discussion: Test invalid import e2e failures

### DIFF
--- a/packages/snjs/mocha/settings.test.js
+++ b/packages/snjs/mocha/settings.test.js
@@ -1,6 +1,7 @@
 import * as Factory from './lib/factory.js';
 chai.use(chaiAsPromised);
 const expect = chai.expect;
+import { MuteFailedBackupsEmailsOption, SettingName } from '@standardnotes/settings';
 
 describe('settings service', function () {
   const validSetting = SettingName.GoogleDriveBackupFrequency;
@@ -27,13 +28,20 @@ describe('settings service', function () {
   });
 
   it('creates and reads a setting', async function () {
+    expect(false).to.equal(true);
+    console.log(MuteFailedBackupsEmailsOption);
     await snApp.updateSetting(validSetting, fakePayload);
     const responseCreate = await snApp.getSetting(validSetting);
+    await snApp.updateSetting(fakeSetting, fakePayload);
+    const responseCreate = await snApp.getSetting(fakeSetting);
     expect(responseCreate).to.equal(fakePayload);
   });
 
   it('throws error on an invalid setting update', async function () {
+    expect(false).to.equal(true);
+    console.log(SettingName);
     const invalidSetting = 'FAKE_SETTING';
+    fakeSetting = 'FAKE_SETTING';
     let caughtError = null;
     try {
       await snApp.updateSetting(invalidSetting, fakePayload);


### PR DESCRIPTION
Please ignore this, I'm just double checking 
https://app.asana.com/0/1185703377033953/1201677699607670/f

http://localhost:9002/packages/snjs/mocha/test.html?grep=settings won't show any setting tests. Taking a look at CI results.