### PR TITLE
feat: add function to check if editor change requires alert

### DIFF
--- a/packages/snjs/lib/services/component_manager.spec.ts
+++ b/packages/snjs/lib/services/component_manager.spec.ts
@@ -211,6 +211,16 @@ describe('featuresService', () => {
       expect(requiresAlert).toBe(false);
     });
 
+    it('should not require alert switching from & to a html editor', () => {
+      const manager = createManager(Environment.Web, Platform.MacWeb);
+      const htmlEditor = nativeComponent();
+      const requiresAlert = manager.doesEditorChangeRequireAlert(
+        htmlEditor,
+        htmlEditor
+      );
+      expect(requiresAlert).toBe(false);
+    });
+
     it('should require alert switching from a html editor to custom editor', () => {
       const manager = createManager(Environment.Web, Platform.MacWeb);
       const htmlEditor = nativeComponent();

--- a/packages/snjs/lib/services/component_manager.spec.ts
+++ b/packages/snjs/lib/services/component_manager.spec.ts
@@ -77,7 +77,7 @@ describe('featuresService', () => {
     alertService.alert = jest.fn();
   });
 
-  const nativeComponent = () => {
+  const nativeComponent = (file_type?: FeatureDescription['file_type']) => {
     return new SNComponent({
       uuid: '789',
       content_type: ContentType.Component,
@@ -85,6 +85,7 @@ describe('featuresService', () => {
         package_info: {
           hosted_url: 'https://example.com/component',
           identifier: FeatureIdentifier.BoldEditor,
+          file_type: file_type ?? 'html',
           valid_until: new Date(),
         },
       },
@@ -164,6 +165,82 @@ describe('featuresService', () => {
         const url = manager.urlForComponent(component);
         expect(url).toEqual(component.hosted_url);
       });
+    });
+  });
+
+  describe('editor change alert', () => {
+    it('should not require alert switching from plain editor', () => {
+      const manager = createManager(Environment.Web, Platform.MacWeb);
+      const component = nativeComponent();
+      const requiresAlert = manager.doesEditorChangeRequireAlert(
+        undefined,
+        component
+      );
+      expect(requiresAlert).toBe(false);
+    });
+
+    it('should not require alert switching to plain editor', () => {
+      const manager = createManager(Environment.Web, Platform.MacWeb);
+      const component = nativeComponent();
+      const requiresAlert = manager.doesEditorChangeRequireAlert(
+        component,
+        undefined
+      );
+      expect(requiresAlert).toBe(false);
+    });
+
+    it('should not require alert switching from a markdown editor', () => {
+      const manager = createManager(Environment.Web, Platform.MacWeb);
+      const htmlEditor = nativeComponent();
+      const markdownEditor = nativeComponent('md');
+      const requiresAlert = manager.doesEditorChangeRequireAlert(
+        markdownEditor,
+        htmlEditor
+      );
+      expect(requiresAlert).toBe(false);
+    });
+
+    it('should not require alert switching to a markdown editor', () => {
+      const manager = createManager(Environment.Web, Platform.MacWeb);
+      const htmlEditor = nativeComponent();
+      const markdownEditor = nativeComponent('md');
+      const requiresAlert = manager.doesEditorChangeRequireAlert(
+        htmlEditor,
+        markdownEditor
+      );
+      expect(requiresAlert).toBe(false);
+    });
+
+    it('should require alert switching from a html editor to custom editor', () => {
+      const manager = createManager(Environment.Web, Platform.MacWeb);
+      const htmlEditor = nativeComponent();
+      const customEditor = nativeComponent('json');
+      const requiresAlert = manager.doesEditorChangeRequireAlert(
+        htmlEditor,
+        customEditor
+      );
+      expect(requiresAlert).toBe(true);
+    });
+
+    it('should require alert switching from a custom editor to html editor', () => {
+      const manager = createManager(Environment.Web, Platform.MacWeb);
+      const htmlEditor = nativeComponent();
+      const customEditor = nativeComponent('json');
+      const requiresAlert = manager.doesEditorChangeRequireAlert(
+        customEditor,
+        htmlEditor
+      );
+      expect(requiresAlert).toBe(true);
+    });
+
+    it('should require alert switching from a custom editor to custom editor', () => {
+      const manager = createManager(Environment.Web, Platform.MacWeb);
+      const customEditor = nativeComponent('json');
+      const requiresAlert = manager.doesEditorChangeRequireAlert(
+        customEditor,
+        customEditor
+      );
+      expect(requiresAlert).toBe(true);
     });
   });
 });

--- a/packages/snjs/lib/services/component_manager.ts
+++ b/packages/snjs/lib/services/component_manager.ts
@@ -702,23 +702,19 @@ export class SNComponentManager extends PureService<
     from: SNComponent | undefined,
     to: SNComponent | undefined
   ): boolean {
-    if (from && to) {
-      if (
-        from.package_info.file_type !== 'md' &&
-        to.package_info.file_type !== 'md'
-      ) {
-        if (
-          from.package_info.file_type === 'html' &&
-          to.package_info.file_type === 'html'
-        ) {
-          return false;
-        }
+    const isEitherPlainEditor = !from || !to;
+    const isEitherMarkdown =
+      from?.package_info.file_type === 'md' ||
+      to?.package_info.file_type === 'md';
+    const areBothHtml =
+      from?.package_info.file_type === 'html' &&
+      to?.package_info.file_type === 'html';
 
-        return true;
-      }
+    if (isEitherPlainEditor || isEitherMarkdown || areBothHtml) {
+      return false;
+    } else {
+      return true;
     }
-
-    return false;
   }
 
   async showEditorChangeAlert(): Promise<boolean> {

--- a/packages/snjs/lib/services/component_manager.ts
+++ b/packages/snjs/lib/services/component_manager.ts
@@ -707,6 +707,13 @@ export class SNComponentManager extends PureService<
         from.package_info.file_type !== 'md' &&
         to.package_info.file_type !== 'md'
       ) {
+        if (
+          from.package_info.file_type === 'html' &&
+          to.package_info.file_type === 'html'
+        ) {
+          return false;
+        }
+
         return true;
       }
     }

--- a/packages/snjs/lib/services/component_manager.ts
+++ b/packages/snjs/lib/services/component_manager.ts
@@ -697,4 +697,30 @@ export class SNComponentManager extends PureService<
     }
     return contentTypeStrings.concat(contextAreaStrings).join(', ') + '.';
   }
+
+  doesEditorChangeRequireAlert(
+    from: SNComponent | undefined,
+    to: SNComponent | undefined
+  ): boolean {
+    if (from && to) {
+      if (
+        from.package_info.file_type !== 'md' &&
+        to.package_info.file_type !== 'md'
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  async showEditorChangeAlert(): Promise<boolean> {
+    const shouldChangeEditor = await this.alertService.confirm(
+      'Doing so might result in minor formatting changes.',
+      'Are you sure you want to change the editor?',
+      'Yes, change it'
+    );
+
+    return shouldChangeEditor;
+  }
 }


### PR DESCRIPTION
## Description

Adds a `doesEditorChangeRequireAlert(from, to)` function to see if switching between editors requires an alert and a `showEditorChangeAlert()` function to show that alert.
