### PR TITLE
fix: sqs image to support arm64 and amd64 architecture

### DIFF
--- a/docker-compose.canary.yml
+++ b/docker-compose.canary.yml
@@ -23,6 +23,45 @@ services:
     networks:
       - snjs
 
+  sns:
+    image: s12v/sns
+    expose:
+      - 9911
+    volumes:
+      - ./docker/sns.json:/etc/sns/db.json
+      - ./wait-for.sh:/etc/scripts/wait-for.sh
+    restart: unless-stopped
+    entrypoint: [
+      "./etc/scripts/wait-for.sh", "sqs", "9324",
+      "java", "-jar", "/sns.jar"
+    ]
+    networks:
+      snjs:
+        aliases:
+          - sns
+
+  sqs:
+    image: softwaremill/elasticmq-native
+    expose:
+      - 9324
+    volumes:
+      - ./docker/sqs.conf:/opt/elasticmq.conf
+    restart: unless-stopped
+    networks:
+      - snjs
+
+  mock-event-publisher:
+    image: standardnotes/mock-event-publisher
+    entrypoint: [
+      "./wait-for.sh", "sns", "9911",
+      "./docker/entrypoint.sh", "start-web"
+    ]
+    ports:
+      - 3124:3000
+    env_file: docker/mock-event-publisher.env
+    networks:
+      - snjs
+
   cache:
     image: redis:6.0-alpine
     expose:
@@ -89,6 +128,7 @@ services:
       - auth
     entrypoint: [
       "./wait-for.sh", "auth", "3000",
+      "./wait-for.sh", "sqs", "9324",
       "./docker/entrypoint.sh", "start-worker"
     ]
     env_file: docker/auth.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,11 +41,11 @@ services:
           - sns
 
   sqs:
-    image: s12v/elasticmq
+    image: softwaremill/elasticmq-native
     expose:
       - 9324
     volumes:
-      - ./docker/sqs.conf:/etc/elasticmq/elasticmq.conf
+      - ./docker/sqs.conf:/opt/elasticmq.conf
     restart: unless-stopped
     networks:
       - snjs


### PR DESCRIPTION
## Description

This image of ElasticMq should support both amd64 and arm64 architecture.

## Related Issue(s)

[Internal link](https://app.asana.com/0/1201389347530783/1201748156300213/f)

## Checklist

- [x] This PR has NO tests
