### PR TITLE
fix: set sync tokens after local processing completes so that if erro…

### DIFF
--- a/packages/snjs/lib/services/sync/account/operation.ts
+++ b/packages/snjs/lib/services/sync/account/operation.ts
@@ -65,14 +65,18 @@ export class AccountSyncOperation {
       this.checkIntegrity,
       undefined,
       undefined
-    ) as RawSyncResponse);
+    )) as RawSyncResponse;
     const response = new SyncResponse(rawResponse);
 
     this.responses.push(response);
     this.lastSyncToken = response.lastSyncToken!;
     this.paginationToken = response.paginationToken!;
 
-    await this.receiver(SyncSignal.Response, response);
+    try {
+      await this.receiver(SyncSignal.Response, response);
+    } catch (error) {
+      console.error('Sync handle response error', error);
+    }
 
     if (!this.done) {
       return this.run();

--- a/packages/snjs/lib/services/sync/sync_service.ts
+++ b/packages/snjs/lib/services/sync/sync_service.ts
@@ -870,8 +870,7 @@ export class SNSyncService extends PureService<
       operation.id,
       response.rawResponse
     );
-    this.setLastSyncToken(response.lastSyncToken!);
-    this.setPaginationToken(response.paginationToken!);
+
     this.opStatus.clearError();
     this.opStatus.setDownloadStatus(response.retrievedPayloads.length);
 
@@ -919,7 +918,13 @@ export class SNSyncService extends PureService<
     if (deletedPayloads.length > 0) {
       await this.deletePayloads(deletedPayloads);
     }
-    await this.notifyEvent(SyncEvent.SingleSyncCompleted, response);
+
+    await Promise.all([
+      this.setLastSyncToken(response.lastSyncToken!),
+      this.setPaginationToken(response.paginationToken!),
+      this.notifyEvent(SyncEvent.SingleSyncCompleted, response),
+    ]);
+
     if (response.checkIntegrity) {
       const clientHash = await this.computeDataIntegrityHash();
       await this.state!.setIntegrityHashes(


### PR DESCRIPTION
…r occurs in between, next sync reattempts to fetch with previous tokens