### PR TITLE
fix(note): prevents unknown types from breaking note's state when creating from PayloadContent

### DIFF
--- a/packages/snjs/lib/models/app/note.spec.ts
+++ b/packages/snjs/lib/models/app/note.spec.ts
@@ -47,4 +47,15 @@ describe('SNNote Tests', () => {
     expect(note.preview_plain).toBeFalsy()
     expect(note.preview_html).toBeFalsy()
   })
+
+  it('should set mobilePrefersPlainEditor when given a valid choice', () => {
+    const selected = create({
+      mobilePrefersPlainEditor: true
+    })
+
+    const unselected = create()
+
+    expect(selected.mobilePrefersPlainEditor).toBeTruthy()
+    expect(unselected.mobilePrefersPlainEditor).toBe(undefined)
+  })
 });

--- a/packages/snjs/lib/models/app/note.spec.ts
+++ b/packages/snjs/lib/models/app/note.spec.ts
@@ -27,12 +27,14 @@ describe('SNNote Tests', () => {
       typeof note.title,
       typeof note.text,
       typeof note.preview_html,
-      typeof note.preview_plain
+      typeof note.preview_plain,
+      typeof note.hidePreview
     ]).toStrictEqual([
       'string',
       'string',
       'string',
-      'string'
+      'string',
+      'boolean'
     ])
   });
 

--- a/packages/snjs/lib/models/app/note.spec.ts
+++ b/packages/snjs/lib/models/app/note.spec.ts
@@ -1,0 +1,48 @@
+import { SNNote } from '@Lib/index';
+import { FillItemContent } from '@Models/functions';
+import { CreateMaxPayloadFromAnyObject } from '@Payloads/generator';
+import { ContentType } from '@standardnotes/common';
+
+const randUuid = () => String(Math.random());
+
+const create = (payload?: Record<string, unknown>): SNNote => (new SNNote(
+  CreateMaxPayloadFromAnyObject({
+    uuid: randUuid(),
+    content_type: ContentType.Note,
+    content: FillItemContent({ ...payload }),
+  })
+));
+
+describe('SNNote Tests', () => {
+  it('should safely type required fields of Note when creating from PayloadContent', () => {
+    const note = create({
+      title: 'Expected string',
+      text: ['unexpected array'],
+      preview_plain: 'Expected preview',
+      preview_html: {},
+      hidePreview: 'string',
+    });
+
+    expect([
+      typeof note.title,
+      typeof note.text,
+      typeof note.preview_html,
+      typeof note.preview_plain
+    ]).toStrictEqual([
+      'string',
+      'string',
+      'string',
+      'string'
+    ])
+  });
+
+  it('should preserve falsy values when casting from PayloadContent', () => {
+    const note = create({
+      preview_plain: null,
+      preview_html: undefined
+    })
+    
+    expect(note.preview_plain).toBeFalsy()
+    expect(note.preview_html).toBeFalsy()
+  })
+});

--- a/packages/snjs/lib/models/app/note.ts
+++ b/packages/snjs/lib/models/app/note.ts
@@ -27,7 +27,7 @@ export class SNNote extends SNItem implements NoteContent {
   public readonly preview_plain: string;
   public readonly preview_html: string;
   public readonly prefersPlainEditor!: boolean;
-  public readonly spellcheck?: boolean | undefined;
+  public readonly spellcheck?: boolean;
 
   constructor(payload: PurePayload) {
     super(payload);

--- a/packages/snjs/lib/models/app/note.ts
+++ b/packages/snjs/lib/models/app/note.ts
@@ -23,7 +23,7 @@ export class SNNote extends SNItem implements NoteContent {
   public readonly title: string;
   public readonly text: string;
   public readonly mobilePrefersPlainEditor?: boolean;
-  public readonly hidePreview = false;
+  public readonly hidePreview: boolean = false;
   public readonly preview_plain: string;
   public readonly preview_html: string;
   public readonly prefersPlainEditor!: boolean;
@@ -35,7 +35,7 @@ export class SNNote extends SNItem implements NoteContent {
     this.text = String(this.payload.safeContent.text || '');
     this.preview_plain = String(this.payload.safeContent.preview_plain);
     this.preview_html = String(this.payload.safeContent.preview_html);
-    this.hidePreview = this.payload.safeContent.hidePreview;
+    this.hidePreview = Boolean(this.payload.safeContent.hidePreview);
     this.spellcheck = this.payload.safeContent.spellcheck;
 
     if (payload.format === PayloadFormat.DecryptedBareObject) {

--- a/packages/snjs/lib/models/app/note.ts
+++ b/packages/snjs/lib/models/app/note.ts
@@ -31,10 +31,11 @@ export class SNNote extends SNItem implements NoteContent {
 
   constructor(payload: PurePayload) {
     super(payload);
+
     this.title = String(this.payload.safeContent.title || '');
     this.text = String(this.payload.safeContent.text || '');
-    this.preview_plain = String(this.payload.safeContent.preview_plain);
-    this.preview_html = String(this.payload.safeContent.preview_html);
+    this.preview_plain = String(this.payload.safeContent.preview_plain || '');
+    this.preview_html = String(this.payload.safeContent.preview_html || '');
     this.hidePreview = Boolean(this.payload.safeContent.hidePreview);
     this.spellcheck = this.payload.safeContent.spellcheck;
 
@@ -43,6 +44,7 @@ export class SNNote extends SNItem implements NoteContent {
         AppDataField.PrefersPlainEditor
       );
     }
+
     if (!isNullOrUndefined(this.payload.safeContent.mobilePrefersPlainEditor)) {
       this.mobilePrefersPlainEditor = this.payload.safeContent.mobilePrefersPlainEditor;
     }

--- a/packages/snjs/lib/models/app/note.ts
+++ b/packages/snjs/lib/models/app/note.ts
@@ -31,10 +31,10 @@ export class SNNote extends SNItem implements NoteContent {
 
   constructor(payload: PurePayload) {
     super(payload);
-    this.title = this.payload.safeContent.title || '';
-    this.text = this.payload.safeContent.text || '';
-    this.preview_plain = this.payload.safeContent.preview_plain;
-    this.preview_html = this.payload.safeContent.preview_html;
+    this.title = String(this.payload.safeContent.title || '');
+    this.text = String(this.payload.safeContent.text || '');
+    this.preview_plain = String(this.payload.safeContent.preview_plain);
+    this.preview_html = String(this.payload.safeContent.preview_html);
     this.hidePreview = this.payload.safeContent.hidePreview;
     this.spellcheck = this.payload.safeContent.spellcheck;
 


### PR DESCRIPTION
Hi there! :hugs:  

This implementation prevents unknown types from breaking note's state when creating from PayloadContent and the PR describes how to reproduce the problem.

## Description
This implementation prevents notes with unexpected types on a string to leave the app in an unusable state. Even though the problem was detected with `Note.preview_plain: string` it could happen on any field being constructed from PayloadContent since all properties are explicitly typed `any`.  

:warning: I am unsure of typing _Boolean_ since it could cause unexpected behaviour (`Boolean("false") → true`) but I found no test or implementation that would be threatened by it.

### Context
Last week I reported to @moughxyz an issue when logging into my account where my notes would not be loaded and were completely unaccessible outside mobile. 

Since he helped me track down the issue until we found a faulty note and the failure. This issue describes the problem for historical purposes and points out a workaround and possible solutions. 

### Problem
After logging in, opening a previously logged in instance or importing my notes on a blank slate, the following error occurred: 
![image](https://user-images.githubusercontent.com/17554234/155328644-b667600f-199c-445a-8f99-c3aee4a8559d.png)

Despite happening on the TagsState, the problem is related to a single note that didn't have the correctly typed JSON. On `preview_plain`, expecting a string, found an malformed object: `preview_plain: { text }`.

So after the notes were loaded and `emitPayloads` was triggered, Mobx failed to set `preview_plain` when trying to display the notes. 

It is reproducible with the following steps:

1. Open an offline session on https://app.standardnotes.com/
2. Open the Backup Tool (Quick Settings > Open Preferences > Backups > Import a previously saved backup file)
3. Import the [sample file](https://gist.github.com/myreli/770967d025421f749372443894fe4ea8#file-issue-txt)
4. Wait for the import to succeed
5. Try to use the app

### Solution
[Ensuring `plain_text` was correctly typed at runtime](https://github.com/myreli/snjs/blob/c458a6508814e4fb81f4617d12cd98470ae1f7ce/packages/snjs/lib/models/app/note.ts#L37) solved the issue. Since `PurePayload` defines the content as a bunch of "any" key/value pairs, TypeScript disables all checks when constructing the note and later on `NoteState` and `TagState` are expecting `string` but receive `any`.  

### Next Steps
There are a few aspects that I haven't had the time to investigate yet but would probably avoid future issues.
- **Why does it work at version `3.8.21`?** 

    This intrigued me but I haven't investigated. :)

- **How did it happen?**

    I could have used a non-standard editor, but honestly, I can't remember doing so. Either way, this could probably be avoided - official editor or not, by validating input on **EditorKit**. I thought of something in terms of: 
    1. Implement a validation on `generateCustomPreview` of EditorKit to ensure *previews* are always valid (either string or undefined)
    2. Implement a validation on EditorKit to ensure `mode` is always valid (either `JSON`, `text`, `HTML`, etc) and corresponds to its content type

- **Why doesn't break on mobile? Why doesn't break when importing after tags or prefs?**
    
    It does on mobile, but not at first sight. On mobile it works on displaying and opening notes but fails when trying to interact with them, making the app functional in a read-only state.

- **How can we prevent broken notes from breaking app?**

    IMO this is the most important because a single note probably should not make the whole app unusable. Instead, we should isolate it and report back to the user the faulty note. That's probably easier on an "importing" context than reading from API, but still possible. 

    Searching for the fastest fix I came up with a few ideas that don't fix the broken state but prevent it. I ended up implementing a small verification when instantiating notes on SNJS to ensure required properties are safely typed.

## Related Issue(s)
I have not created an issue. However, there is a [related thread on slack](https://standardnotes.slack.com/archives/C3LC7FFP1/p1644599536986069?thread_ts=1644596136.801319&cid=C3LC7FFP1) that describes the initial issue when it occurred.

## Checklist

- [ ] Solution reviewed with maintainer
- [x] All package's unit tests pass 
![image](https://user-images.githubusercontent.com/17554234/155392500-7dc6623d-de46-45aa-9833-ebe7b81e9be9.png)

