### PR TITLE
feat: inject internal event bus to services for seamless event publishing

### DIFF
--- a/packages/services/src/Domain/Service/AbstractService.ts
+++ b/packages/services/src/Domain/Service/AbstractService.ts
@@ -4,12 +4,18 @@ import { ApplicationStage } from '@standardnotes/applications'
 import { DeviceInterface } from '../Device/DeviceInterface'
 import { EventObserver } from '../Event/EventObserver'
 import { ServiceInterface } from './ServiceInterface'
+import { InternalEventBusInterface } from '../Internal/InternalEventBusInterface'
 
 export abstract class AbstractService<EventName = string, EventData = undefined> implements ServiceInterface<EventName, EventData> {
   private eventObservers: EventObserver<EventName, EventData>[] = []
   public loggingEnabled = false
   public deviceInterface?: DeviceInterface
   private criticalPromises: Promise<unknown>[] = []
+
+  constructor(
+    protected internalEventBus: InternalEventBusInterface
+  ) {
+  }
 
   public addEventObserver(
     observer: EventObserver<EventName, EventData>
@@ -27,6 +33,11 @@ export abstract class AbstractService<EventName = string, EventData = undefined>
     for (const observer of this.eventObservers) {
       await observer(eventName, data)
     }
+
+    this.internalEventBus.publish({
+      type: (eventName as unknown) as string,
+      payload: data,
+    })
   }
 
   /**

--- a/packages/snjs/lib/application.ts
+++ b/packages/snjs/lib/application.ts
@@ -1738,6 +1738,7 @@ export class SNApplication implements ListedInterface {
       this.itemManager,
       this.settingsService,
       this.httpService,
+      this.internalEventBus,
     )
     this.services.push(this.listedService)
   }
@@ -1749,6 +1750,7 @@ export class SNApplication implements ListedInterface {
       this.syncService,
       this.alertService,
       this.options.crypto,
+      this.internalEventBus,
     )
 
     this.services.push(this.fileService)
@@ -1767,6 +1769,7 @@ export class SNApplication implements ListedInterface {
       this.sessionManager,
       this.options.crypto,
       this.options.runtime,
+      this.internalEventBus,
     )
     this.serviceObservers.push(
       this.featuresService.addEventObserver((event) => {
@@ -1789,7 +1792,11 @@ export class SNApplication implements ListedInterface {
   }
 
   private createWebSocketsService() {
-    this.webSocketsService = new SNWebSocketsService(this.storageService, this.options.webSocketUrl)
+    this.webSocketsService = new SNWebSocketsService(
+      this.storageService,
+      this.options.webSocketUrl,
+      this.internalEventBus,
+    )
     this.services.push(this.webSocketsService)
   }
 
@@ -1805,6 +1812,7 @@ export class SNApplication implements ListedInterface {
       featuresService: this.featuresService,
       environment: this.environment,
       identifier: this.identifier,
+      internalEventBus: this.internalEventBus,
     })
     this.services.push(this.migrationService)
   }
@@ -1819,6 +1827,7 @@ export class SNApplication implements ListedInterface {
       this.alertService,
       this.challengeService,
       this.protectionService,
+      this.internalEventBus,
     )
     this.serviceObservers.push(
       this.credentialService.addEventObserver((event) => {
@@ -1840,15 +1849,18 @@ export class SNApplication implements ListedInterface {
     this.apiService = new SNApiService(
       this.httpService,
       this.storageService,
-      this.internalEventBus,
       this.options.defaultHost,
       this.options.defaultFilesHost,
+      this.internalEventBus,
     )
     this.services.push(this.apiService)
   }
 
   private createItemManager() {
-    this.itemManager = new ItemManager(this.payloadManager)
+    this.itemManager = new ItemManager(
+      this.payloadManager,
+      this.internalEventBus,
+    )
     this.services.push(this.itemManager)
   }
 
@@ -1864,22 +1876,33 @@ export class SNApplication implements ListedInterface {
       this.environment,
       this.platform,
       this.options.runtime,
+      this.internalEventBus,
     )
     this.services.push(this.componentManager)
   }
 
   private createHttpManager() {
-    this.httpService = new SNHttpService(this.environment, this.options.appVersion)
+    this.httpService = new SNHttpService(
+      this.environment,
+      this.options.appVersion,
+      this.internalEventBus,
+    )
     this.services.push(this.httpService)
   }
 
   private createPayloadManager() {
-    this.payloadManager = new PayloadManager()
+    this.payloadManager = new PayloadManager(
+      this.internalEventBus,
+    )
     this.services.push(this.payloadManager)
   }
 
   private createSingletonManager() {
-    this.singletonManager = new SNSingletonManager(this.itemManager, this.syncService)
+    this.singletonManager = new SNSingletonManager(
+      this.itemManager,
+      this.syncService,
+      this.internalEventBus,
+    )
     this.services.push(this.singletonManager)
   }
 
@@ -1889,6 +1912,7 @@ export class SNApplication implements ListedInterface {
       this.alertService,
       this.identifier,
       this.environment,
+      this.internalEventBus,
     )
     this.services.push(this.storageService)
   }
@@ -1901,6 +1925,7 @@ export class SNApplication implements ListedInterface {
       this.storageService,
       this.identifier,
       this.options.crypto,
+      this.internalEventBus,
     )
     this.protocolService.onKeyStatusChange(async () => {
       await this.notifyEvent(ApplicationEvent.KeyStatusChanged)
@@ -1919,6 +1944,7 @@ export class SNApplication implements ListedInterface {
       this.storageService,
       this.syncService,
       this.credentialService,
+      this.internalEventBus,
     )
     this.services.push(this.keyRecoveryService)
   }
@@ -1931,6 +1957,7 @@ export class SNApplication implements ListedInterface {
       this.protocolService,
       this.challengeService,
       this.webSocketsService,
+      this.internalEventBus,
     )
     this.serviceObservers.push(
       this.sessionManager.addEventObserver(async (event) => {
@@ -1971,6 +1998,7 @@ export class SNApplication implements ListedInterface {
       {
         loadBatchSize: this.options.loadBatchSize,
       },
+      this.internalEventBus,
     )
     const syncEventCallback = async (eventName: SyncEvent) => {
       const appEvent = applicationEventForSyncEvent(eventName)
@@ -1991,7 +2019,11 @@ export class SNApplication implements ListedInterface {
   }
 
   private createChallengeService() {
-    this.challengeService = new ChallengeService(this.storageService, this.protocolService)
+    this.challengeService = new ChallengeService(
+      this.storageService,
+      this.protocolService,
+      this.internalEventBus,
+    )
     this.services.push(this.challengeService)
   }
 
@@ -2001,6 +2033,7 @@ export class SNApplication implements ListedInterface {
       this.challengeService,
       this.storageService,
       this.itemManager,
+      this.internalEventBus,
     )
     this.serviceObservers.push(
       this.protectionService.addEventObserver((event) => {
@@ -2021,6 +2054,7 @@ export class SNApplication implements ListedInterface {
       this.apiService,
       this.protocolService,
       this.deviceInterface,
+      this.internalEventBus,
     )
     this.services.push(this.historyManager)
   }
@@ -2036,6 +2070,7 @@ export class SNApplication implements ListedInterface {
       this.syncService,
       this.challengeService,
       this.listedService,
+      this.internalEventBus,
     )
     this.services.push(this.actionsManager)
   }
@@ -2045,6 +2080,7 @@ export class SNApplication implements ListedInterface {
       this.singletonManager,
       this.itemManager,
       this.syncService,
+      this.internalEventBus,
     )
     this.serviceObservers.push(
       this.preferencesService.addEventObserver(() => {
@@ -2055,7 +2091,11 @@ export class SNApplication implements ListedInterface {
   }
 
   private createSettingsService() {
-    this.settingsService = new SNSettingsService(this.sessionManager, this.apiService)
+    this.settingsService = new SNSettingsService(
+      this.sessionManager,
+      this.apiService,
+      this.internalEventBus,
+    )
     this.services.push(this.settingsService)
   }
 
@@ -2064,6 +2104,7 @@ export class SNApplication implements ListedInterface {
       this.settingsService,
       this.options.crypto,
       this.featuresService,
+      this.internalEventBus,
     )
     this.services.push(this.mfaService)
   }

--- a/packages/snjs/lib/application_group.ts
+++ b/packages/snjs/lib/application_group.ts
@@ -2,7 +2,7 @@ import { RawStorageKey } from '@Lib/storage_keys'
 import { removeFromArray } from '@standardnotes/utils'
 import { DeinitSource, UuidString } from './types'
 import { SNApplication } from './application'
-import { AbstractService, DeviceInterface } from '@standardnotes/services'
+import { AbstractService, DeviceInterface, InternalEventBus, InternalEventBusInterface } from '@standardnotes/services'
 import { UuidGenerator } from '@standardnotes/utils'
 
 export type ApplicationDescriptor = {
@@ -30,8 +30,10 @@ export class SNApplicationGroup extends AbstractService {
   callback!: AppGroupCallback
   private applications: SNApplication[] = []
 
-  constructor(public deviceInterface: DeviceInterface) {
-    super()
+  constructor(
+    public deviceInterface: DeviceInterface,
+  ) {
+    super(new InternalEventBus())
   }
 
   deinit() {

--- a/packages/snjs/lib/application_group.ts
+++ b/packages/snjs/lib/application_group.ts
@@ -32,8 +32,13 @@ export class SNApplicationGroup extends AbstractService {
 
   constructor(
     public deviceInterface: DeviceInterface,
+    internalEventBus?: InternalEventBusInterface,
   ) {
-    super(new InternalEventBus())
+    if (internalEventBus === undefined) {
+      internalEventBus = new InternalEventBus()
+    }
+
+    super(internalEventBus)
   }
 
   deinit() {

--- a/packages/snjs/lib/migrations/types.ts
+++ b/packages/snjs/lib/migrations/types.ts
@@ -4,7 +4,7 @@ import { ItemManager } from '@Lib/services/ItemManager'
 import { Environment } from './../platforms'
 import { SNStorageService } from '@Lib/services/StorageService'
 import { SNProtocolService } from '../services/ProtocolService'
-import { DeviceInterface } from '@standardnotes/services'
+import { DeviceInterface, InternalEventBusInterface } from '@standardnotes/services'
 import { ChallengeService, SNSingletonManager, SNFeaturesService } from '@Lib/services'
 
 /** Services that the migration service needs to function */
@@ -20,4 +20,5 @@ export type MigrationServices = {
   environment: Environment
   /** The application identifier */
   identifier: ApplicationIdentifier
+  internalEventBus: InternalEventBusInterface,
 }

--- a/packages/snjs/lib/services/ActionsService.ts
+++ b/packages/snjs/lib/services/ActionsService.ts
@@ -21,7 +21,7 @@ import { PayloadManager } from './PayloadManager'
 import { SNHttpService } from './Api/HttpService'
 import { SNAlertService } from './AlertService'
 
-import { AbstractService, DeviceInterface } from '@standardnotes/services'
+import { AbstractService, DeviceInterface, InternalEventBusInterface } from '@standardnotes/services'
 
 /**
  * The Actions Service allows clients to interact with action-based extensions.
@@ -50,8 +50,9 @@ export class SNActionsService extends AbstractService {
     private syncService: SNSyncService,
     private challengeService: ChallengeService,
     private listedService: ListedService,
+    protected internalEventBus: InternalEventBusInterface,
   ) {
-    super()
+    super(internalEventBus)
     this.previousPasswords = []
   }
 

--- a/packages/snjs/lib/services/Api/ApiService.ts
+++ b/packages/snjs/lib/services/Api/ApiService.ts
@@ -148,11 +148,11 @@ export class SNApiService
   constructor(
     private httpService: SNHttpService,
     private storageService: SNStorageService,
-    private internalEventBus: InternalEventBusInterface,
     private host: string,
     private filesHost: string,
+    protected internalEventBus: InternalEventBusInterface,
   ) {
-    super()
+    super(internalEventBus)
   }
 
   /** @override */
@@ -275,14 +275,6 @@ export class SNApiService
       this.notifyEvent(ApiServiceEvent.MetaReceived, {
         userUuid: meta.auth.userUuid,
         userRoles: meta.auth.roles,
-      })
-
-      this.internalEventBus.publish({
-        type: ApiServiceEvent.MetaReceived,
-        payload: {
-          userUuid: meta.auth.userUuid,
-          userRoles: meta.auth.roles,
-        }
       })
     }
   }

--- a/packages/snjs/lib/services/Api/HttpService.ts
+++ b/packages/snjs/lib/services/Api/HttpService.ts
@@ -3,7 +3,7 @@ import { HttpResponse, StatusCode } from '@standardnotes/responses'
 import { isNullOrUndefined, isString } from '@standardnotes/utils'
 import { SnjsVersion } from '@Lib/version'
 import { Environment } from '@Lib/platforms'
-import { AbstractService } from '@standardnotes/services'
+import { AbstractService, InternalEventBusInterface } from '@standardnotes/services'
 
 export enum HttpVerb {
   Get = 'GET',
@@ -35,9 +35,14 @@ export type HttpRequest = {
  * A non-SNJS specific wrapper for XMLHttpRequests
  */
 export class SNHttpService extends AbstractService {
-  constructor(private readonly environment: Environment, private readonly appVersion: string) {
-    super()
+  constructor(
+    private readonly environment: Environment,
+    private readonly appVersion: string,
+    protected internalEventBus: InternalEventBusInterface,
+  ) {
+    super(internalEventBus)
   }
+
   public async getAbsolute(
     url: string,
     params?: HttpParams,

--- a/packages/snjs/lib/services/Api/SessionManager.ts
+++ b/packages/snjs/lib/services/Api/SessionManager.ts
@@ -28,7 +28,7 @@ import * as messages from './Messages'
 import { PromptTitles, RegisterStrings, SessionStrings, SignInStrings } from './Messages'
 import { UuidString } from '@Lib/types'
 import { SNWebSocketsService } from './WebsocketsService'
-import { AbstractService } from '@standardnotes/services'
+import { AbstractService, InternalEventBusInterface } from '@standardnotes/services'
 
 export const MINIMUM_PASSWORD_LENGTH = 8
 export const MissingAccountParams = 'missing-params'
@@ -64,8 +64,9 @@ export class SNSessionManager extends AbstractService<SessionEvent> {
     private protocolService: SNProtocolService,
     private challengeService: ChallengeService,
     private webSocketsService: SNWebSocketsService,
+    protected internalEventBus: InternalEventBusInterface,
   ) {
-    super()
+    super(internalEventBus)
     apiService.setInvalidSessionObserver((revoked) => {
       if (revoked) {
         void this.notifyEvent(SessionEvent.Revoked)

--- a/packages/snjs/lib/services/Api/WebsocketsService.spec.ts
+++ b/packages/snjs/lib/services/Api/WebsocketsService.spec.ts
@@ -1,3 +1,4 @@
+import { InternalEventBusInterface } from '@standardnotes/services'
 import { StorageKey, SNStorageService } from '@Lib/index'
 import { SNWebSocketsService } from './WebsocketsService'
 
@@ -5,14 +6,18 @@ describe('webSocketsService', () => {
   const webSocketUrl = ''
 
   let storageService: SNStorageService
+  let internalEventBus: InternalEventBusInterface
 
   const createService = () => {
-    return new SNWebSocketsService(storageService, webSocketUrl)
+    return new SNWebSocketsService(storageService, webSocketUrl, internalEventBus)
   }
 
   beforeEach(() => {
     storageService = {} as jest.Mocked<SNStorageService>
     storageService.setValue = jest.fn()
+
+    internalEventBus = {} as jest.Mocked<InternalEventBusInterface>
+    internalEventBus.publish = jest.fn()
   })
 
   describe('setWebSocketUrl()', () => {

--- a/packages/snjs/lib/services/Api/WebsocketsService.ts
+++ b/packages/snjs/lib/services/Api/WebsocketsService.ts
@@ -1,7 +1,7 @@
 import { UserRolesChangedEvent } from '@standardnotes/domain-events'
 import { StorageKey } from '@Lib/storage_keys'
 import { SNStorageService } from '../StorageService'
-import { AbstractService } from '@standardnotes/services'
+import { AbstractService, InternalEventBusInterface } from '@standardnotes/services'
 
 export enum WebSocketsServiceEvent {
   UserRoleMessageReceived = 'WebSocketMessageReceived',
@@ -13,8 +13,12 @@ export class SNWebSocketsService extends AbstractService<
 > {
   private webSocket?: WebSocket
 
-  constructor(private storageService: SNStorageService, private webSocketUrl: string | undefined) {
-    super()
+  constructor(
+    private storageService: SNStorageService,
+    private webSocketUrl: string | undefined,
+    protected internalEventBus: InternalEventBusInterface,
+  ) {
+    super(internalEventBus)
   }
 
   public async setWebSocketUrl(url: string | undefined): Promise<void> {

--- a/packages/snjs/lib/services/ApplicationService.ts
+++ b/packages/snjs/lib/services/ApplicationService.ts
@@ -1,12 +1,15 @@
 import { ApplicationEvent } from '@Lib/events'
-import { AbstractService } from '@standardnotes/services'
+import { AbstractService, InternalEventBusInterface } from '@standardnotes/services'
 import { SNApplication } from '../application'
 
 export class ApplicationService extends AbstractService {
   private unsubApp: any
 
-  constructor(protected application: SNApplication) {
-    super()
+  constructor(
+    protected application: SNApplication,
+    protected internalEventBus: InternalEventBusInterface,
+  ) {
+    super(internalEventBus)
     /* Allow caller constructor to finish setting instance variables before triggering callbacks */
     setTimeout(() => {
       this.addAppEventObserver()

--- a/packages/snjs/lib/services/Challenge/ChallengeService.ts
+++ b/packages/snjs/lib/services/Challenge/ChallengeService.ts
@@ -12,7 +12,7 @@ import {
 import { ChallengeOperation } from './ChallengeOperation'
 import { removeFromArray } from '@standardnotes/utils'
 import { isValidProtectionSessionLength } from '../ProtectionService'
-import { AbstractService } from '@standardnotes/services'
+import { AbstractService, InternalEventBusInterface } from '@standardnotes/services'
 
 type ChallengeValidationResponse = {
   valid: boolean
@@ -40,8 +40,9 @@ export class ChallengeService extends AbstractService {
   constructor(
     private storageService: SNStorageService,
     private protocolService: SNProtocolService,
+    protected internalEventBus: InternalEventBusInterface,
   ) {
-    super()
+    super(internalEventBus)
   }
 
   /** @override */

--- a/packages/snjs/lib/services/ComponentManager/ComponentManager.spec.ts
+++ b/packages/snjs/lib/services/ComponentManager/ComponentManager.spec.ts
@@ -16,6 +16,7 @@ import { ItemManager } from '@Lib/services/ItemManager'
 import { SNFeaturesService } from '@Lib/services/Features/FeaturesService'
 import { SNComponentManager } from './ComponentManager'
 import { SNSyncService } from '../Sync/SyncService'
+import { InternalEventBusInterface } from '@standardnotes/services'
 
 describe('featuresService', () => {
   let itemManager: ItemManager
@@ -23,6 +24,7 @@ describe('featuresService', () => {
   let alertService: SNAlertService
   let syncService: SNSyncService
   let prefsService: SNPreferencesService
+  let internalEventBus: InternalEventBusInterface
 
   const desktopExtHost = 'http://localhost:123'
 
@@ -46,6 +48,7 @@ describe('featuresService', () => {
       environment,
       platform,
       Runtime.Prod,
+      internalEventBus,
     )
     manager.setDesktopManager(desktopManager)
     manager.configureForNonMobileUsage = jest.fn().mockReturnValue(0)
@@ -72,6 +75,9 @@ describe('featuresService', () => {
     alertService = {} as jest.Mocked<SNAlertService>
     alertService.confirm = jest.fn()
     alertService.alert = jest.fn()
+
+    internalEventBus = {} as jest.Mocked<InternalEventBusInterface>
+    internalEventBus.publish = jest.fn()
   })
 
   const nativeComponent = (file_type?: FeatureDescription['file_type']) => {

--- a/packages/snjs/lib/services/ComponentManager/ComponentManager.ts
+++ b/packages/snjs/lib/services/ComponentManager/ComponentManager.ts
@@ -24,7 +24,7 @@ import {
   AllowedBatchPermissions,
 } from '@Lib/services/ComponentManager/types'
 import { ActionObserver, ComponentViewer } from '@Lib/services/ComponentManager/ComponentViewer'
-import { AbstractService } from '@standardnotes/services'
+import { AbstractService, InternalEventBusInterface } from '@standardnotes/services'
 
 const DESKTOP_URL_PREFIX = 'sn://'
 const LOCAL_HOST = 'localhost'
@@ -59,8 +59,9 @@ export class SNComponentManager extends AbstractService<ComponentManagerEvent, E
     private environment: Environment,
     private platform: Platform,
     private runtime: Runtime,
+    protected internalEventBus: InternalEventBusInterface,
   ) {
-    super()
+    super(internalEventBus)
     this.loggingEnabled = false
     this.addItemObserver()
     if (environment !== Environment.Mobile) {

--- a/packages/snjs/lib/services/CredentialService.ts
+++ b/packages/snjs/lib/services/CredentialService.ts
@@ -26,7 +26,7 @@ import { SNSyncService } from './Sync/SyncService'
 import { SNSessionManager, MINIMUM_PASSWORD_LENGTH } from './Api/SessionManager'
 import { ChallengeService } from './Challenge/ChallengeService'
 import { SNItemsKey } from '@Lib/models'
-import { AbstractService } from '@standardnotes/services'
+import { AbstractService, InternalEventBusInterface } from '@standardnotes/services'
 
 const MINIMUM_PASSCODE_LENGTH = 1
 
@@ -50,8 +50,9 @@ export class SNCredentialService extends AbstractService<AccountEvent> {
     private alertService: SNAlertService,
     private challengeService: ChallengeService,
     private protectionService: SNProtectionService,
+    protected internalEventBus: InternalEventBusInterface,
   ) {
-    super()
+    super(internalEventBus)
   }
 
   public deinit(): void {

--- a/packages/snjs/lib/services/Features/FeaturesService.spec.ts
+++ b/packages/snjs/lib/services/Features/FeaturesService.spec.ts
@@ -19,6 +19,7 @@ import { SNWebSocketsService } from '../Api/WebsocketsService'
 import { SNSettingsService } from '../Settings'
 import { SNPureCrypto } from '@standardnotes/sncrypto-common'
 import { convertTimestampToMilliseconds } from '@standardnotes/utils'
+import { InternalEventBusInterface } from '@standardnotes/services'
 
 describe('featuresService', () => {
   let storageService: SNStorageService
@@ -37,6 +38,7 @@ describe('featuresService', () => {
   let now: Date
   let tomorrow_server: number
   let tomorrow_client: number
+  let internalEventBus: InternalEventBusInterface
   const expiredDate = new Date(new Date().getTime() - 1000).getTime()
 
   const createService = () => {
@@ -52,6 +54,7 @@ describe('featuresService', () => {
       sessionManager,
       crypto,
       Runtime.Prod,
+      internalEventBus,
     )
   }
 
@@ -123,6 +126,9 @@ describe('featuresService', () => {
 
     crypto = {} as jest.Mocked<SNPureCrypto>
     crypto.base64Decode = jest.fn()
+
+    internalEventBus = {} as jest.Mocked<InternalEventBusInterface>
+    internalEventBus.publish = jest.fn()
   })
 
   describe('experimental features', () => {

--- a/packages/snjs/lib/services/Features/FeaturesService.ts
+++ b/packages/snjs/lib/services/Features/FeaturesService.ts
@@ -51,7 +51,7 @@ import {
   OfflineSubscriptionEntitlements,
   SetOfflineFeaturesFunctionResponse,
 } from './Types'
-import { AbstractService, InternalEventHandlerInterface, InternalEventInterface } from '@standardnotes/services'
+import { AbstractService, InternalEventBusInterface, InternalEventHandlerInterface, InternalEventInterface } from '@standardnotes/services'
 
 type GetOfflineSubscriptionDetailsResponse = OfflineSubscriptionEntitlements | ErrorObject
 
@@ -82,8 +82,9 @@ export class SNFeaturesService
     private sessionManager: SNSessionManager,
     private crypto: SNPureCrypto,
     private runtime: Runtime,
+    protected internalEventBus: InternalEventBusInterface,
   ) {
-    super()
+    super(internalEventBus)
 
     this.removeWebSocketsServiceObserver = webSocketsService.addEventObserver(
       async (eventName, data) => {

--- a/packages/snjs/lib/services/Files/FileService.ts
+++ b/packages/snjs/lib/services/Files/FileService.ts
@@ -10,7 +10,7 @@ import { ItemManager } from '@Lib/services/ItemManager'
 import { SNApiService } from '../Api/ApiService'
 import { isErrorObject, UuidGenerator } from '@standardnotes/utils'
 import { PayloadContent, FillItemContent } from '@standardnotes/payloads'
-import { AbstractService } from '@standardnotes/services'
+import { AbstractService, InternalEventBusInterface } from '@standardnotes/services'
 
 export interface FilesClientInterface {
   beginNewFileUpload(): Promise<EncryptAndUploadFileOperation>
@@ -40,8 +40,9 @@ export class SNFileService extends AbstractService implements FilesClientInterfa
     private syncService: SNSyncService,
     private alertService: SNAlertService,
     private crypto: SNPureCrypto,
+    protected internalEventBus: InternalEventBusInterface,
   ) {
-    super()
+    super(internalEventBus)
   }
 
   deinit(): void {

--- a/packages/snjs/lib/services/History/HistoryManager.ts
+++ b/packages/snjs/lib/services/History/HistoryManager.ts
@@ -7,7 +7,7 @@ import {
   PayloadSource,
   PayloadFormat,
 } from '@standardnotes/payloads'
-import { AbstractService, DeviceInterface } from '@standardnotes/services'
+import { AbstractService, DeviceInterface, InternalEventBusInterface } from '@standardnotes/services'
 import { HistoryEntry } from '@Lib/services/History/Entries/HistoryEntry'
 import { CreateHistoryEntryForPayload } from '@Lib/services/History/Entries/Generator'
 import { UuidString } from '../../types'
@@ -82,8 +82,9 @@ export class SNHistoryManager extends AbstractService {
     private apiService: SNApiService,
     private protocolService: SNProtocolService,
     public deviceInterface: DeviceInterface,
+    protected internalEventBus: InternalEventBusInterface,
   ) {
-    super()
+    super(internalEventBus)
     this.removeChangeObserver = this.itemManager.addObserver(
       this.historyTypes,
       (changed, inserted) => {

--- a/packages/snjs/lib/services/ItemManager.spec.ts
+++ b/packages/snjs/lib/services/ItemManager.spec.ts
@@ -11,6 +11,7 @@ import { UuidGenerator } from '@standardnotes/utils'
 import { ContentType } from '@standardnotes/common'
 import { NotesDisplayCriteria } from '../protocol/collection/notes_display_criteria'
 import { PayloadManager } from './PayloadManager'
+import { InternalEventBusInterface } from '@standardnotes/services'
 
 const setupRandomUuid = () => {
   UuidGenerator.SetGenerator(() => String(Math.random()))
@@ -42,13 +43,20 @@ describe('itemManager', () => {
   let payloadManager: PayloadManager
   let itemManager: ItemManager
   let items: SNItem[]
+  let internalEventBus: InternalEventBusInterface
 
   const createService = () => {
-    return new ItemManager(payloadManager)
+    return new ItemManager(
+      payloadManager,
+      internalEventBus,
+    )
   }
 
   beforeEach(() => {
-    payloadManager = new PayloadManager()
+    internalEventBus = {} as jest.Mocked<InternalEventBusInterface>
+    internalEventBus.publish = jest.fn()
+
+    payloadManager = new PayloadManager(internalEventBus)
 
     items = [] as jest.Mocked<SNItem[]>
     itemManager = {} as jest.Mocked<ItemManager>

--- a/packages/snjs/lib/services/ItemManager.ts
+++ b/packages/snjs/lib/services/ItemManager.ts
@@ -40,7 +40,7 @@ import { ItemMutator, MutationType, SNItem } from '../models/core/item'
 import { TagNoteCountChangeObserver, TagNotesIndex } from '../protocol/collection/tag_notes_index'
 import { UuidString } from '../types'
 import { PayloadManager } from './PayloadManager'
-import { AbstractService } from '@standardnotes/services'
+import { AbstractService, InternalEventBusInterface } from '@standardnotes/services'
 import { BuildSmartViews } from '@Lib/protocol/collection/smart_view_builder'
 
 type ObserverCallback = (
@@ -88,8 +88,11 @@ export class ItemManager extends AbstractService {
   private systemSmartViews: SmartView[]
   private tagNotesIndex!: TagNotesIndex
 
-  constructor(private payloadManager: PayloadManager) {
-    super()
+  constructor(
+    private payloadManager: PayloadManager,
+    protected internalEventBus: InternalEventBusInterface,
+  ) {
+    super(internalEventBus)
     this.payloadManager = payloadManager
     this.systemSmartViews = this.rebuildSystemSmartViews(NotesDisplayCriteria.Create({}))
     this.createCollection()

--- a/packages/snjs/lib/services/KeyRecoveryService.ts
+++ b/packages/snjs/lib/services/KeyRecoveryService.ts
@@ -27,7 +27,7 @@ import { dateSorted, isNullOrUndefined, removeFromArray } from '@standardnotes/u
 import { KeyParamsFromApiResponse } from '@Lib/protocol/key_params'
 import { UuidString } from '@Lib/types'
 import { KeyParamsResponse } from '@standardnotes/responses'
-import { AbstractService } from '@standardnotes/services'
+import { AbstractService, InternalEventBusInterface } from '@standardnotes/services'
 
 /**
  * The key recovery service listens to items key changes to detect any that cannot be decrypted.
@@ -97,8 +97,9 @@ export class SNKeyRecoveryService extends AbstractService {
     private storageService: SNStorageService,
     private syncService: SNSyncService,
     private credentialService: SNCredentialService,
+    protected internalEventBus: InternalEventBusInterface,
   ) {
-    super()
+    super(internalEventBus)
     this.removeItemObserver = this.itemManager.addObserver(
       [ContentType.ItemsKey],
       (changed, inserted, _discarded, ignored, source) => {

--- a/packages/snjs/lib/services/ListedService.ts
+++ b/packages/snjs/lib/services/ListedService.ts
@@ -13,7 +13,7 @@ import {
   ListedAccountInfo,
   ListedAccountInfoResponse,
 } from '@standardnotes/responses'
-import { AbstractService } from '@standardnotes/services'
+import { AbstractService, InternalEventBusInterface } from '@standardnotes/services'
 
 export class ListedService extends AbstractService implements ListedInterface {
   constructor(
@@ -21,8 +21,9 @@ export class ListedService extends AbstractService implements ListedInterface {
     private itemManager: ItemManager,
     private settingsService: SNSettingsService,
     private httpSerivce: SNHttpService,
+    protected internalEventBus: InternalEventBusInterface,
   ) {
-    super()
+    super(internalEventBus)
   }
 
   public canRegisterNewListedAccount(): boolean {

--- a/packages/snjs/lib/services/MfaService.ts
+++ b/packages/snjs/lib/services/MfaService.ts
@@ -5,15 +5,16 @@ import * as messages from './Api/Messages'
 import { SNPureCrypto } from '@standardnotes/sncrypto-common'
 import { SNFeaturesService } from './Features/FeaturesService'
 import { FeatureIdentifier } from '@standardnotes/features'
-import { AbstractService } from '@standardnotes/services'
+import { AbstractService, InternalEventBusInterface } from '@standardnotes/services'
 
 export class SNMfaService extends AbstractService {
   constructor(
     private settingsService: SNSettingsService,
     private crypto: SNPureCrypto,
     private featuresService: SNFeaturesService,
+    protected internalEventBus: InternalEventBusInterface,
   ) {
-    super()
+    super(internalEventBus)
   }
 
   private async saveMfaSetting(secret: string): Promise<void> {

--- a/packages/snjs/lib/services/MigrationService.ts
+++ b/packages/snjs/lib/services/MigrationService.ts
@@ -23,8 +23,10 @@ export class SNMigrationService extends AbstractService {
   private activeMigrations?: Migration[]
   private baseMigration!: BaseMigration
 
-  constructor(private services: MigrationServices) {
-    super()
+  constructor(
+    private services: MigrationServices,
+  ) {
+    super(services.internalEventBus)
   }
 
   public deinit(): void {

--- a/packages/snjs/lib/services/PayloadManager.ts
+++ b/packages/snjs/lib/services/PayloadManager.ts
@@ -10,7 +10,7 @@ import { DeltaFileImport } from '../protocol/payloads/deltas/file_import'
 import { ContentType } from '@standardnotes/common'
 import { Uuids } from '@Models/functions'
 import { UuidString } from '../types'
-import { AbstractService } from '@standardnotes/services'
+import { AbstractService, InternalEventBusInterface } from '@standardnotes/services'
 
 type ChangeCallback = (
   changed: PurePayload[],
@@ -57,8 +57,10 @@ export class PayloadManager extends AbstractService {
    */
   private overwriteProtection: ContentType[] = [ContentType.ItemsKey]
 
-  constructor() {
-    super()
+  constructor(
+    protected internalEventBus: InternalEventBusInterface,
+  ) {
+    super(internalEventBus)
     this.collection = new MutableCollection()
   }
 

--- a/packages/snjs/lib/services/PreferencesService.ts
+++ b/packages/snjs/lib/services/PreferencesService.ts
@@ -6,7 +6,7 @@ import { SNSingletonManager } from './SingletonManager'
 import { SNSyncService } from './Sync/SyncService'
 import { SyncEvent } from './Sync/Events'
 import { ApplicationStage } from '@standardnotes/applications'
-import { AbstractService } from '@standardnotes/services'
+import { AbstractService, InternalEventBusInterface } from '@standardnotes/services'
 import { FillItemContent } from '@standardnotes/payloads'
 
 const preferencesChangedEvent = 'preferencesChanged'
@@ -23,8 +23,9 @@ export class SNPreferencesService extends AbstractService<PreferencesChangedEven
     private singletonManager: SNSingletonManager,
     private itemManager: ItemManager,
     private syncService: SNSyncService,
+    protected internalEventBus: InternalEventBusInterface,
   ) {
-    super()
+    super(internalEventBus)
 
     this.removeItemObserver = itemManager.addObserver(ContentType.UserPrefs, () => {
       this.shouldReload = true

--- a/packages/snjs/lib/services/ProtectionService.ts
+++ b/packages/snjs/lib/services/ProtectionService.ts
@@ -9,7 +9,7 @@ import { isNullOrUndefined } from '@standardnotes/utils'
 import { ApplicationStage } from '@standardnotes/applications'
 import { ItemManager } from './ItemManager'
 import { Uuids } from '@Lib/models/functions'
-import { AbstractService } from '@standardnotes/services'
+import { AbstractService, InternalEventBusInterface } from '@standardnotes/services'
 
 export enum ProtectionEvent {
   UnprotectedSessionBegan = 'UnprotectedSessionBegan',
@@ -63,8 +63,9 @@ export class SNProtectionService extends AbstractService<ProtectionEvent> {
     private challengeService: ChallengeService,
     private storageService: SNStorageService,
     private itemManager: ItemManager,
+    protected internalEventBus: InternalEventBusInterface,
   ) {
-    super()
+    super(internalEventBus)
   }
 
   public deinit(): void {

--- a/packages/snjs/lib/services/ProtocolService.ts
+++ b/packages/snjs/lib/services/ProtocolService.ts
@@ -56,7 +56,7 @@ import {
 } from '@standardnotes/applications'
 import { StorageKey } from '@Lib/storage_keys'
 import { StorageValueModes } from '@Lib/services/StorageService'
-import { AbstractService, DeviceInterface } from '@standardnotes/services'
+import { AbstractService, DeviceInterface, InternalEventBusInterface } from '@standardnotes/services'
 
 export type BackupFile = {
   version?: ProtocolVersion
@@ -134,8 +134,9 @@ export class SNProtocolService extends AbstractService implements EncryptionDele
     private storageService: SNStorageService,
     private identifier: ApplicationIdentifier,
     crypto: SNPureCrypto,
+    protected internalEventBus: InternalEventBusInterface,
   ) {
-    super()
+    super(internalEventBus)
     this.itemManager = itemManager
     this.payloadManager = payloadManager
     this.deviceInterface = deviceInterface

--- a/packages/snjs/lib/services/Settings/SNSettingsService.ts
+++ b/packages/snjs/lib/services/Settings/SNSettingsService.ts
@@ -4,7 +4,7 @@ import { SNSessionManager } from '../Api/SessionManager'
 import { CloudProvider, EmailBackupFrequency, SettingName } from '@standardnotes/settings'
 import { SensitiveSettingName } from './SensitiveSettingName'
 import { ExtensionsServerURL } from '@Lib/hosts'
-import { AbstractService } from '@standardnotes/services'
+import { AbstractService, InternalEventBusInterface } from '@standardnotes/services'
 
 export class SNSettingsService extends AbstractService {
   private provider!: SettingsGateway
@@ -23,8 +23,9 @@ export class SNSettingsService extends AbstractService {
   constructor(
     private readonly sessionManager: SNSessionManager,
     private readonly apiService: SNApiService,
+    protected internalEventBus: InternalEventBusInterface,
   ) {
-    super()
+    super(internalEventBus)
   }
 
   initializeFromDisk(): void {

--- a/packages/snjs/lib/services/SingletonManager.ts
+++ b/packages/snjs/lib/services/SingletonManager.ts
@@ -15,7 +15,7 @@ import {
 import { SyncEvent } from '@Lib/services/Sync/Events'
 import { SNSyncService } from './Sync/SyncService'
 import { Uuids } from '@Models/functions'
-import { AbstractService } from '@standardnotes/services'
+import { AbstractService, InternalEventBusInterface } from '@standardnotes/services'
 
 /**
  * The singleton manager allow consumers to ensure that only 1 item exists of a certain
@@ -34,8 +34,12 @@ export class SNSingletonManager extends AbstractService {
   private removeItemObserver!: () => void
   private removeSyncObserver!: () => void
 
-  constructor(private itemManager: ItemManager, private syncService: SNSyncService) {
-    super()
+  constructor(
+    private itemManager: ItemManager,
+    private syncService: SNSyncService,
+    protected internalEventBus: InternalEventBusInterface,
+  ) {
+    super(internalEventBus)
     this.itemManager = itemManager
     this.syncService = syncService
     this.addObservers()

--- a/packages/snjs/lib/services/StorageService.ts
+++ b/packages/snjs/lib/services/StorageService.ts
@@ -13,7 +13,7 @@ import { EncryptionDelegate } from './EncryptionDelegate'
 import { SNRootKey } from '@Protocol/root_key'
 import { ContentType } from '@standardnotes/common'
 import { Copy, isNullOrUndefined, UuidGenerator } from '@standardnotes/utils'
-import { AbstractService, DeviceInterface } from '@standardnotes/services'
+import { AbstractService, DeviceInterface, InternalEventBusInterface } from '@standardnotes/services'
 
 export enum StoragePersistencePolicies {
   Default = 1,
@@ -73,8 +73,9 @@ export class SNStorageService extends AbstractService {
     private alertService: SNAlertService,
     private identifier: string,
     private environment: Environment,
+    protected internalEventBus: InternalEventBusInterface,
   ) {
-    super()
+    super(internalEventBus)
     this.deviceInterface = deviceInterface
     this.setPersistencePolicy(StoragePersistencePolicies.Default)
     this.setEncryptionPolicy(StorageEncryptionPolicies.Default, false)

--- a/packages/snjs/lib/services/Sync/SyncService.ts
+++ b/packages/snjs/lib/services/Sync/SyncService.ts
@@ -34,7 +34,7 @@ import { SyncSignal, SyncStats } from '@Lib/services/Sync/Signals'
 import { SNSessionManager } from '../Api/SessionManager'
 import { SNApiService } from '../Api/ApiService'
 import { SNLog } from '@Lib/log'
-import { AbstractService } from '@standardnotes/services'
+import { AbstractService, InternalEventBusInterface } from '@standardnotes/services'
 
 const DEFAULT_MAX_DISCORDANCE = 5
 const DEFAULT_MAJOR_CHANGE_THRESHOLD = 15
@@ -152,8 +152,9 @@ export class SNSyncService extends AbstractService<
     private apiService: SNApiService,
     private historyService: SNHistoryManager,
     private readonly options: ApplicationSyncOptions,
+    protected internalEventBus: InternalEventBusInterface,
   ) {
-    super()
+    super(internalEventBus)
     this.initializeStatus()
     this.initializeState()
   }


### PR DESCRIPTION
## Description

Injecting the internal event bus to all services so that whenever `notifyEvent` is called, we are also seamlessly publishing an internal event with the same data.

## Related Issue(s)

[Internal link](https://app.asana.com/0/1160985268757881/1201831657647589/f)

## Checklist

- [ ] This PR has NO tests
