### PR TITLE
feat: allow passing file or filehandle to reader as param

### DIFF
--- a/packages/filepicker/src/classic_reader.ts
+++ b/packages/filepicker/src/classic_reader.ts
@@ -22,7 +22,14 @@ export class ClassicFileReader {
     return 50 * 1_000_000
   }
 
-  selectFile(): Promise<File> {
+  selectFile(file?: File): Promise<File> {
+    if (file) {
+      return new Promise((resolve) => {
+        this.selectedFile = file
+        resolve(file)
+      })
+    }
+
     const input = document.createElement('input') as HTMLInputElement
     input.type = 'file'
     return new Promise((resolve) => {

--- a/packages/filepicker/src/streaming_reader.ts
+++ b/packages/filepicker/src/streaming_reader.ts
@@ -26,11 +26,15 @@ export class StreamingFileReader {
     return window.showOpenFilePicker != undefined
   }
 
-  public async selectFile(): Promise<File> {
-    const selectedFilesHandles = await window.showOpenFilePicker()
-    const uploadHandle = selectedFilesHandles[0]
+  public async selectFile(fileHandle?: FileSystemFileHandle): Promise<File> {
+    if (fileHandle) {
+      this.selectedFile = await fileHandle.getFile()
+    } else {
+      const selectedFilesHandles = await window.showOpenFilePicker()
+      const uploadHandle = selectedFilesHandles[0]
 
-    this.selectedFile = await uploadHandle.getFile()
+      this.selectedFile = await uploadHandle.getFile()
+    }
 
     return this.selectedFile
   }


### PR DESCRIPTION
## Description

Adds an optional `file` or `fileHandle` param to `selectFile()`

## Checklist

- [x] This PR has NO tests
