### PR TITLE
fix: add missing legacy email field on key params data

### DIFF
--- a/packages/responses/src/Domain/Auth/KeyParamsData.ts
+++ b/packages/responses/src/Domain/Auth/KeyParamsData.ts
@@ -7,6 +7,7 @@ export type KeyParamsData = {
   version?: ProtocolVersion
   /** Legacy V002 */
   pw_salt?: string
+  email?: string
   /** Legacy V001 */
   pw_func?: string
   pw_alg?: string


### PR DESCRIPTION
## Description

Add missing legacy email field for KeyParams response from the server which is present in protocols 002 and 001

## Related Issue(s)

N/A

## Checklist

- [x] This PR has NO tests
