### PR TITLE
fix: export enums without declaring them with 'const'

### DIFF
--- a/packages/snjs/lib/services/ComponentManager/ComponentManager.ts
+++ b/packages/snjs/lib/services/ComponentManager/ComponentManager.ts
@@ -32,7 +32,7 @@ const LOCAL_HOST = 'localhost'
 const CUSTOM_LOCAL_HOST = 'sn.local'
 const ANDROID_LOCAL_HOST = '10.0.2.2'
 
-export const enum ComponentManagerEvent {
+export enum ComponentManagerEvent {
   ViewerDidFocus = 'ViewerDidFocus',
 }
 

--- a/packages/snjs/lib/services/ComponentManager/ComponentViewer.ts
+++ b/packages/snjs/lib/services/ComponentManager/ComponentViewer.ts
@@ -73,12 +73,12 @@ const ReadwriteActions = [
 
 export type ActionObserver = (action: ComponentAction, messageData: MessageData) => void
 
-export const enum ComponentViewerEvent {
+export enum ComponentViewerEvent {
   FeatureStatusUpdated = 'FeatureStatusUpdated',
 }
 type EventObserver = (event: ComponentViewerEvent) => void
 
-export const enum ComponentViewerError {
+export enum ComponentViewerError {
   OfflineRestricted = 'OfflineRestricted',
   MissingUrl = 'MissingUrl',
 }

--- a/packages/snjs/lib/services/Features/Types.ts
+++ b/packages/snjs/lib/services/Features/Types.ts
@@ -7,12 +7,12 @@ export type OfflineSubscriptionEntitlements = {
   extensionKey: string
 }
 
-export const enum FeaturesEvent {
+export enum FeaturesEvent {
   UserRolesChanged = 'UserRolesChanged',
   FeaturesUpdated = 'FeaturesUpdated',
 }
 
-export const enum FeatureStatus {
+export enum FeatureStatus {
   NoUserSubscription = 'NoUserSubscription',
   NotInCurrentPlan = 'NotInCurrentPlan',
   InCurrentPlanButExpired = 'InCurrentPlanButExpired',

--- a/packages/snjs/lib/services/Session/SessionManager.ts
+++ b/packages/snjs/lib/services/Session/SessionManager.ts
@@ -64,7 +64,7 @@ const cleanedEmailString = (email: string) => {
   return email.trim().toLowerCase()
 }
 
-export const enum SessionEvent {
+export enum SessionEvent {
   Restored = 'SessionRestored',
   Revoked = 'SessionRevoked',
 }

--- a/packages/snjs/lib/services/User/UserService.ts
+++ b/packages/snjs/lib/services/User/UserService.ts
@@ -35,7 +35,7 @@ const MINIMUM_PASSCODE_LENGTH = 1
 export type CredentialsChangeFunctionResponse = { error?: { message: string } }
 export type AccountServiceResponse = HttpResponse
 
-export const enum AccountEvent {
+export enum AccountEvent {
   SignedInOrRegistered = 'SignedInOrRegistered',
   SignedOut = 'SignedOut',
 }


### PR DESCRIPTION
## Description

Export enums without declaring them as `const`

Otherwise TypeScript throws the following error when using them in other modules, where `isolatedModules` flag is set to TRUE:
`Cannot access ambient const enums when the '--isolatedModules' flag is provided.`
(see [here](https://ncjamieson.com/dont-export-const-enums/) for explanation)

## Related Issue(s)

<!--- link(s) to the issue(s) -->

## Checklist

- [ ] This PR has NO tests
