### PR TITLE
feat: add GB support to formatSizeAsReadableString

### DIFF
--- a/packages/filepicker/src/utils.spec.ts
+++ b/packages/filepicker/src/utils.spec.ts
@@ -39,7 +39,7 @@ describe('utils', () => {
       expect(formattedSize).toBe('999 B')
     })
 
-    it('should show as bytes if more than or equal to 1KB', () => {
+    it('should format as KB if more than 1000 bytes', () => {
       const size = 1_000
 
       const formattedSize = formatSizeToReadableString(size)
@@ -47,12 +47,20 @@ describe('utils', () => {
       expect(formattedSize).toBe('1 KB')
     })
 
-    it('should show as bytes if more than or equal to 1MB', () => {
+    it('should format as MB if more than 1000000 bytes', () => {
       const size = 1_000_000
 
       const formattedSize = formatSizeToReadableString(size)
 
       expect(formattedSize).toBe('1 MB')
+    })
+
+    it('should format as GB if more than 1000000000 bytes', () => {
+      const size = 1_000_000_000
+
+      const formattedSize = formatSizeToReadableString(size)
+
+      expect(formattedSize).toBe('1 GB')
     })
 
     it('should only show fixed-point notation if calculated size is not an integer', () => {

--- a/packages/filepicker/src/utils.ts
+++ b/packages/filepicker/src/utils.ts
@@ -17,9 +17,7 @@ export function parseFileName(fileName: string): {
   const pattern = /(?:\.([^.]+))?$/
   const extMatches = pattern.exec(fileName)
   const ext = extMatches?.[1] || ''
-  const name = fileName.includes('.')
-    ? fileName.substring(0, fileName.lastIndexOf('.'))
-    : fileName
+  const name = fileName.includes('.') ? fileName.substring(0, fileName.lastIndexOf('.')) : fileName
 
   return { name, ext }
 }
@@ -39,11 +37,15 @@ export function saveFile(name: string, bytes: Uint8Array): void {
 
 const BYTES_IN_ONE_KILOBYTE = 1_000
 const BYTES_IN_ONE_MEGABYTE = 1_000_000
+const BYTES_IN_ONE_GIGABYTE = 1_000_000_000
 
 export function formatSizeToReadableString(bytes: number): string {
   let size = bytes
   let unit = 'B'
-  if (bytes >= BYTES_IN_ONE_MEGABYTE) {
+  if (bytes >= BYTES_IN_ONE_GIGABYTE) {
+    size = bytes / BYTES_IN_ONE_GIGABYTE
+    unit = 'GB'
+  } else if (bytes >= BYTES_IN_ONE_MEGABYTE) {
     size = bytes / BYTES_IN_ONE_MEGABYTE
     unit = 'MB'
   } else if (bytes >= BYTES_IN_ONE_KILOBYTE) {


### PR DESCRIPTION
## Description

Adds GB support to `formatSizeAsReadableString` function, and adds a test for it. Required for displaying files quota correctly.

## Checklist

- [ ] This PR has NO tests
