### PR TITLE
fix: update auth to allow expired token session sign outs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       - snjs
 
   auth:
-    image: standardnotes/auth:dev
+    image: standardnotes/auth:1.43.0
     depends_on:
       - syncing-server-js
     entrypoint: [
@@ -114,7 +114,7 @@ services:
       - snjs
 
   auth-worker:
-    image: standardnotes/auth:dev
+    image: standardnotes/auth:1.43.0
     depends_on:
       - auth
     entrypoint: [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       - snjs
 
   auth:
-    image: standardnotes/auth:1.42.0
+    image: standardnotes/auth:dev
     depends_on:
       - syncing-server-js
     entrypoint: [
@@ -114,7 +114,7 @@ services:
       - snjs
 
   auth-worker:
-    image: standardnotes/auth:1.42.0
+    image: standardnotes/auth:dev
     depends_on:
       - auth
     entrypoint: [

--- a/packages/snjs/mocha/session.test.js
+++ b/packages/snjs/mocha/session.test.js
@@ -172,7 +172,7 @@ describe('server session', function () {
     expect(syncResponse.error.message).to.equal('Invalid login credentials.')
   })
 
-  it.skip('sign out request should be performed successfully and terminate session with expired access token', async function () {
+  it('sign out request should be performed successfully and terminate session with expired access token', async function () {
     this.timeout(Factory.TwentySecondTimeout)
 
     await Factory.registerUserToApplication({


### PR DESCRIPTION
## Description

Allow expired token request for session sign out

## Related Issue(s)

[Internal Link](https://app.asana.com/0/1160985268757888/1202162717384437/f)

## Checklist

- [ ] This PR has NO tests
