### PR TITLE
fix: do not send custom headers for external request

### DIFF
--- a/packages/snjs/lib/Services/Api/ApiService.ts
+++ b/packages/snjs/lib/Services/Api/ApiService.ts
@@ -187,6 +187,7 @@ export class SNApiService
     authentication?: string
     customHeaders?: Record<string, string>[]
     responseType?: XMLHttpRequestResponseType
+    external?: boolean
   }) {
     try {
       const response = await this.httpService.runHttp(params)
@@ -636,6 +637,7 @@ export class SNApiService
     return this.request({
       verb: HttpVerb.Get,
       url,
+      external: true,
       fallbackErrorMessage: messages.API_MESSAGE_GENERIC_INVALID_LOGIN,
     })
   }

--- a/packages/snjs/lib/Services/Api/HttpService.ts
+++ b/packages/snjs/lib/Services/Api/HttpService.ts
@@ -24,6 +24,7 @@ export type HttpRequest = {
   authentication?: string
   customHeaders?: Record<string, string>[]
   responseType?: XMLHttpRequestResponseType
+  external?: boolean
 }
 
 /**
@@ -83,13 +84,15 @@ export class SNHttpService extends AbstractService {
     request.open(httpRequest.verb, httpRequest.url, true)
     request.responseType = httpRequest.responseType ?? ''
 
-    request.setRequestHeader('X-SNJS-Version', SnjsVersion)
+    if (!httpRequest.external) {
+      request.setRequestHeader('X-SNJS-Version', SnjsVersion)
 
-    const appVersionHeaderValue = `${Environment[this.environment]}-${this.appVersion}`
-    request.setRequestHeader('X-Application-Version', appVersionHeaderValue)
+      const appVersionHeaderValue = `${Environment[this.environment]}-${this.appVersion}`
+      request.setRequestHeader('X-Application-Version', appVersionHeaderValue)
 
-    if (httpRequest.authentication) {
-      request.setRequestHeader('Authorization', 'Bearer ' + httpRequest.authentication)
+      if (httpRequest.authentication) {
+        request.setRequestHeader('Authorization', 'Bearer ' + httpRequest.authentication)
+      }
     }
 
     let contenTypeIsSet = false
@@ -101,7 +104,7 @@ export class SNHttpService extends AbstractService {
         }
       })
     }
-    if (!contenTypeIsSet) {
+    if (!contenTypeIsSet && !httpRequest.external) {
       request.setRequestHeader('Content-Type', 'application/json')
     }
 


### PR DESCRIPTION
Fixes issue where downloading external extensions from places like https://cdn.jsdelivr.net/gh/dracula/standard-notes@master/sn-theme-dracula.json would fail due to destination rejecting custom headers.